### PR TITLE
Fix install-vips.sh for macOS and improve developer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,25 @@ Example:
 docker run -v ~/konifer-test/config.conf:/app/config/konifer.conf -p 8080:8080 konifer
 ```
 
+### Docker Compose
+
+Docker Compose is the easiest way to run Konifer along with its dependencies (Postgres and MinIO). A `konifer.conf` must exist in the repo root before starting — one is already provided.
+
+```shell
+docker compose up
+```
+
+By default, Compose pulls the pre-built image from `ghcr.io`. If you want to run your locally built image instead, edit `docker-compose.yml` and replace the `image:` line with the `build:` block:
+
+```yaml
+# image: ghcr.io/dmaiken/konifer:0.1.0
+build:
+  context: .
+  dockerfile: Dockerfile
+```
+
+> **macOS (Apple Silicon):** The pre-built image is `amd64` only. Use the local `build:` block above to build a native `arm64` image instead.
+
 ### JOOQ
 This project used [JOOQ](https://www.jooq.org/) as it's interface to the database. JOOQ generates the code based on the database schema.
 This is done within the `codegen` module. Running the code generator will:

--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ docker run -v ~/konifer-test/config.conf:/app/config/konifer.conf -p 8080:8080 k
 
 ### Docker Compose
 
-Docker Compose is the easiest way to run Konifer along with its dependencies (Postgres and MinIO). A `konifer.conf` must exist in the repo root before starting — one is already provided.
+Docker Compose is the easiest way to run Konifer along with its dependencies (Postgres and MinIO). A `konifer.conf` must exist in the repo root before starting.
 
 ```shell
 docker compose up

--- a/README.md
+++ b/README.md
@@ -299,15 +299,29 @@ ensures you're developing against the same version that Konifer will use within 
 
 To install:
 ```shell
-chmod +x /scripts/install-vips.sh && ./scripts/install-vips.sh --with-deps                                                                                                                                                                                                                                                                                                                      luci
+chmod +x ./scripts/install-vips.sh && ./scripts/install-vips.sh --with-deps
 ```
+
+> **macOS:** If you get a `Compiler cc cannot compile programs` error, you need to install Xcode Command Line Tools first:
+> ```shell
+> xcode-select --install
+> ```
 
 ## Docker
 
-To build the docker image for this (highly recommended since it will contain all libraries needed by VIPS):
+To build the docker image for this (highly recommended since it will contain all libraries needed by VIPS), first build the JAR, then build the image:
 ```shell
-docker build . -t konifer:latest
+./gradlew :service:shadowJar && docker build . -t konifer:latest
 ```
+
+> **macOS:** If you get `Unable to locate a Java Runtime`, install GraalVM (used by the project) via Homebrew:
+> ```shell
+> brew install --cask graalvm-jdk@25
+> ```
+> If you still get a `JAVA_HOME` error after installing, run:
+> ```shell
+> export JAVA_HOME=$(/usr/libexec/java_home)
+> ```
 Then, to run, mount a file to `/app/config/konifer.conf`:
 ```shell
 docker run -v path/to/your/conf/file:/app/config/konifer.conf -p 8080:8080 konifer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   konifer:
     container_name: konifer
      # If building locally, comment out image: and uncomment the section below
-#    build:
-#      context: .
-#      dockerfile: Dockerfile
+    # build:
+    #  context: .
+    #  dockerfile: Dockerfile
     image: ghcr.io/dmaiken/konifer:0.1.0
     ports:
       - "8080:8080"

--- a/scripts/install-vips.sh
+++ b/scripts/install-vips.sh
@@ -21,19 +21,33 @@ while [[ "$#" -gt 0 ]]; do
   esac
 done
 
-echo "Starting VIPS setup. Version: $VIPS_VERSION, Prefix: $PREFIX"
+# Detect OS
+OS="$(uname -s)"
 
-# System Dependencies (Debian/Ubuntu specific)
+echo "Starting VIPS setup. Version: $VIPS_VERSION, Prefix: $PREFIX, OS: $OS"
+
+# System Dependencies
 if [ "$INSTALL_DEPS" = true ]; then
   echo "Installing system dependencies..."
-  apt-get update && apt-get install -y \
-    build-essential pkg-config ninja-build wget meson \
-    glib2.0-dev libexif-dev libexpat1-dev libfftw3-dev \
-    libimagequant-dev libjpeg-turbo8-dev liblcms2-dev \
-    libpango1.0-dev libpng-dev \
-    libwebp-dev libheif-dev libde265-dev \
-    libjxl-dev libgif-dev libcgif-dev libaom-dev \
-    libheif-plugin-x265 libheif-plugin-aomenc libjemalloc-dev
+  if [ "$OS" = "Darwin" ]; then
+    brew install \
+      pkg-config ninja meson \
+      glib libexif expat fftw \
+      libimagequant jpeg-turbo little-cms2 \
+      pango libpng \
+      webp libheif libde265 \
+      jpeg-xl giflib cgif aom \
+      x265 jemalloc
+  else
+    apt-get update && apt-get install -y \
+      build-essential pkg-config ninja-build curl meson \
+      glib2.0-dev libexif-dev libexpat1-dev libfftw3-dev \
+      libimagequant-dev libjpeg-turbo8-dev liblcms2-dev \
+      libpango1.0-dev libpng-dev \
+      libwebp-dev libheif-dev libde265-dev \
+      libjxl-dev libgif-dev libcgif-dev libaom-dev \
+      libheif-plugin-x265 libheif-plugin-aomenc libjemalloc-dev
+  fi
 fi
 
 echo "Downloading and compiling VIPS..."
@@ -41,14 +55,21 @@ echo "Downloading and compiling VIPS..."
 mkdir -p $BUILD_DIR
 cd $BUILD_DIR
 
-wget "${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz"
+curl -L "${VIPS_URL}/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.xz" -o "vips-${VIPS_VERSION}.tar.xz"
 tar xf "vips-${VIPS_VERSION}.tar.xz"
 cd "vips-${VIPS_VERSION}"
 
 # Configure, Build, Install
 # Note: We install to /usr/local. Local devs might need sudo access for this step
 # or should run this script with sudo.
-LDFLAGS="-ljemalloc" meson setup build \
+if [ "$OS" = "Darwin" ]; then
+  JEMALLOC_PREFIX="$(brew --prefix jemalloc)"
+  LDFLAGS="-L${JEMALLOC_PREFIX}/lib -ljemalloc"
+else
+  LDFLAGS="-ljemalloc"
+fi
+
+LDFLAGS="$LDFLAGS" meson setup build \
   --prefix="$PREFIX" \
   --buildtype=release \
   --libdir=lib \
@@ -69,8 +90,10 @@ if [ "$CLEANUP" = true ]; then
   cd /
   rm -rf $BUILD_DIR
 
-  # Remove build-only dependencies to save space
-  apt-get remove -y build-essential pkg-config ninja-build
-  apt-get autoremove -y
-  rm -rf /var/lib/apt/lists/*
+  if [ "$OS" != "Darwin" ]; then
+    # Remove build-only dependencies to save space
+    apt-get remove -y build-essential pkg-config ninja-build
+    apt-get autoremove -y
+    rm -rf /var/lib/apt/lists/*
+  fi
 fi


### PR DESCRIPTION
## Summary
- Add macOS support to `install-vips.sh`: detect OS via `uname`, use `brew` for deps, resolve jemalloc lib path via `brew --prefix`, skip apt cleanup on Darwin
- Replace `wget` with `curl` (built-in on macOS, installable on Linux)
- Fix broken `install-vips.sh` path in README (`/scripts` → `./scripts`) and remove stray trailing text
- Document prerequisite build step (`gradlew shadowJar`) before `docker build`
- Add macOS-specific notes for Xcode CLT and GraalVM JDK installation
- Add Docker Compose section to README with Apple Silicon note

## Test plan
- [x] Run `./scripts/install-vips.sh --with-deps` on macOS and verify it installs dependencies via Homebrew
- [x] Run `./scripts/install-vips.sh --with-deps` on Linux/Docker and verify it still uses `apt-get`
- [x] Verify `./gradlew :service:shadowJar && docker build . -t konifer:latest` works end-to-end
- [x] Verify `docker compose up` starts all services successfully