### PR TITLE
Fix ordering of query selectors in client

### DIFF
--- a/client/src/commonMain/kotlin/io/konifer/client/Extensions.kt
+++ b/client/src/commonMain/kotlin/io/konifer/client/Extensions.kt
@@ -43,10 +43,10 @@ suspend inline fun <reified T> HttpResponse.toKoniferResponse(): KoniferResponse
     }
 
 fun URLBuilder.appendQuerySelectors(
-    returnFormat: ReturnFormat,
+    returnFormat: ReturnFormat?,
     querySelectors: QuerySelectors,
 ) {
-    appendPathSegments(PATH_SEPARATOR, returnFormat.name.lowercase())
+    appendPathSegments(PATH_SEPARATOR)
     when (querySelectors) {
         is QuerySelectors.EntryId -> {
             appendPathSegments("entry", querySelectors.entryId.toString())
@@ -56,11 +56,9 @@ fun URLBuilder.appendQuerySelectors(
         }
         is QuerySelectors.None -> { } // Nothing
     }
-}
-
-fun URLBuilder.appendEntryId(entryId: Long) {
-    appendPathSegments(PATH_SEPARATOR)
-    appendPathSegments("entry", entryId.toString())
+    returnFormat?.let {
+        appendPathSegments(it.name.lowercase())
+    }
 }
 
 fun URLBuilder.appendTransformationParameters(requestedTransformation: RequestedTransformation) {

--- a/client/src/commonMain/kotlin/io/konifer/client/KoniferClient.kt
+++ b/client/src/commonMain/kotlin/io/konifer/client/KoniferClient.kt
@@ -8,6 +8,7 @@ import io.konifer.common.selector.ReturnFormat
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
 import io.ktor.client.request.forms.ChannelProvider
 import io.ktor.client.request.forms.MultiPartFormDataContent
@@ -67,7 +68,7 @@ class KoniferClient internal constructor(
             followRedirects = false
         }
 
-    suspend fun getAssetMetadata(
+    suspend fun fetchAssetMetadata(
         path: String,
         querySelectors: QuerySelectors = QuerySelectors.None(),
     ): KoniferResponse<AssetResponse> =
@@ -83,7 +84,7 @@ class KoniferClient internal constructor(
                 }.toKoniferResponse()
         }
 
-    suspend fun getAssetMetadata(
+    suspend fun fetchAssetMetadata(
         path: String,
         limit: Int,
         querySelectors: QuerySelectors = QuerySelectors.None(),
@@ -101,7 +102,7 @@ class KoniferClient internal constructor(
                 }.toKoniferResponse()
         }
 
-    suspend fun getAssetContent(
+    suspend fun fetchAssetContent(
         path: String,
         querySelectors: QuerySelectors = QuerySelectors.None(),
         requestedTransformation: RequestedTransformation = RequestedTransformation.OriginalVariant,
@@ -111,15 +112,12 @@ class KoniferClient internal constructor(
         safeApiCall {
             httpClient
                 .prepareGet {
-                    url {
-                        appendPathSegments(ASSETS_BASE_PATH)
-                        appendPathSegments(path.splitPath())
-                        when (fetchMode) {
-                            ContentFetchMode.CONTENT -> appendQuerySelectors(ReturnFormat.CONTENT, querySelectors)
-                            ContentFetchMode.REDIRECT -> appendQuerySelectors(ReturnFormat.REDIRECT, querySelectors)
-                        }
-                        appendTransformationParameters(requestedTransformation)
-                    }
+                    fetchContentUrl(
+                        path = path,
+                        querySelectors = querySelectors,
+                        requestedTransformation = requestedTransformation,
+                        fetchMode = fetchMode,
+                    )
                 }.execute { response ->
                     if (response.status.isSuccess()) {
                         response.bodyAsChannel().copyAndClose(byteChannel)
@@ -131,7 +129,7 @@ class KoniferClient internal constructor(
                 }
         }
 
-    suspend fun getAssetContentBytes(
+    suspend fun fetchAssetContentBytes(
         path: String,
         querySelectors: QuerySelectors = QuerySelectors.None(),
         requestedTransformation: RequestedTransformation = RequestedTransformation.OriginalVariant,
@@ -140,15 +138,12 @@ class KoniferClient internal constructor(
         safeApiCall {
             httpClient
                 .prepareGet {
-                    url {
-                        appendPathSegments(ASSETS_BASE_PATH)
-                        appendPathSegments(path.splitPath())
-                        when (fetchMode) {
-                            ContentFetchMode.CONTENT -> appendQuerySelectors(ReturnFormat.CONTENT, querySelectors)
-                            ContentFetchMode.REDIRECT -> appendQuerySelectors(ReturnFormat.REDIRECT, querySelectors)
-                        }
-                        appendTransformationParameters(requestedTransformation)
-                    }
+                    fetchContentUrl(
+                        path = path,
+                        querySelectors = querySelectors,
+                        requestedTransformation = requestedTransformation,
+                        fetchMode = fetchMode,
+                    )
                 }.execute { response ->
                     if (response.status.isSuccess()) {
                         KoniferResponse.Success(response.bodyAsBytes())
@@ -158,7 +153,7 @@ class KoniferClient internal constructor(
                 }
         }
 
-    suspend fun getAssetRedirectLocation(
+    suspend fun fetchAssetRedirectLocation(
         path: String,
         querySelectors: QuerySelectors = QuerySelectors.None(),
         requestedTransformation: RequestedTransformation = RequestedTransformation.OriginalVariant,
@@ -185,7 +180,7 @@ class KoniferClient internal constructor(
                 }
         }
 
-    suspend fun getAssetLink(
+    suspend fun fetchAssetLink(
         path: String,
         querySelectors: QuerySelectors = QuerySelectors.None(),
         requestedTransformation: RequestedTransformation = RequestedTransformation.OriginalVariant,
@@ -299,7 +294,10 @@ class KoniferClient internal constructor(
                     url {
                         appendPathSegments(ASSETS_BASE_PATH)
                         appendPathSegments(path.splitPath())
-                        appendEntryId(entryId)
+                        appendQuerySelectors(
+                            returnFormat = null,
+                            querySelectors = QuerySelectors.EntryId(entryId),
+                        )
                     }
                     contentType(ContentType.Application.Json)
                     setBody(request)
@@ -324,4 +322,19 @@ class KoniferClient internal constructor(
         } catch (e: Exception) {
             KoniferResponse.NetworkError(e)
         }
+
+    private fun HttpRequestBuilder.fetchContentUrl(
+        path: String,
+        querySelectors: QuerySelectors,
+        requestedTransformation: RequestedTransformation,
+        fetchMode: ContentFetchMode,
+    ) = url {
+        appendPathSegments(ASSETS_BASE_PATH)
+        appendPathSegments(path.splitPath())
+        when (fetchMode) {
+            ContentFetchMode.CONTENT -> appendQuerySelectors(ReturnFormat.CONTENT, querySelectors)
+            ContentFetchMode.REDIRECT -> appendQuerySelectors(ReturnFormat.REDIRECT, querySelectors)
+        }
+        appendTransformationParameters(requestedTransformation)
+    }
 }

--- a/client/src/commonTest/kotlin/io/konifer/client/KoniferClientTest.kt
+++ b/client/src/commonTest/kotlin/io/konifer/client/KoniferClientTest.kt
@@ -1,5 +1,6 @@
 package io.konifer.client
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.ktor.client.HttpClient
@@ -17,7 +18,7 @@ class KoniferClientTest :
             client.close()
 
             shouldThrow<CancellationException> {
-                client.getAssetLink(
+                client.fetchAssetLink(
                     path = "/users/123",
                 )
             }
@@ -30,9 +31,16 @@ class KoniferClientTest :
             client.close()
 
             shouldThrow<CancellationException> {
-                client.getAssetRedirectLocation(
+                client.fetchAssetRedirectLocation(
                     path = "/users/123",
                 )
+            }
+        }
+
+        test("Can build the client") {
+            val baseUrl = "http://localhost:8080"
+            shouldNotThrowAny {
+                KoniferClient.build(baseUrl)
             }
         }
     })

--- a/client/src/commonTest/kotlin/io/konifer/client/content/KoniferClientContentTest.kt
+++ b/client/src/commonTest/kotlin/io/konifer/client/content/KoniferClientContentTest.kt
@@ -37,7 +37,7 @@ class KoniferClientContentTest :
                     responseChannel.toByteArray()
                 }
             val response =
-                koniferClient.getAssetContent(
+                koniferClient.fetchAssetContent(
                     path = "/users/123",
                     byteChannel = responseChannel,
                     fetchMode = ContentFetchMode.CONTENT,
@@ -59,7 +59,7 @@ class KoniferClientContentTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetContentBytes(
+                koniferClient.fetchAssetContentBytes(
                     path = "/users/123",
                 )
             response::class shouldBe KoniferResponse.Success::class
@@ -80,7 +80,7 @@ class KoniferClientContentTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetContentBytes(
+                koniferClient.fetchAssetContentBytes(
                     path = "/users/123",
                 )
             response::class shouldBe KoniferResponse.Success::class
@@ -105,7 +105,7 @@ class KoniferClientContentTest :
                     responseChannel.toByteArray()
                 }
             val response =
-                koniferClient.getAssetContent(
+                koniferClient.fetchAssetContent(
                     path = "/users/123",
                     byteChannel = responseChannel,
                     fetchMode = ContentFetchMode.CONTENT,
@@ -127,7 +127,7 @@ class KoniferClientContentTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetContentBytes(
+                koniferClient.fetchAssetContentBytes(
                     path = "/users/123",
                     fetchMode = ContentFetchMode.REDIRECT,
                 )
@@ -140,7 +140,7 @@ class KoniferClientContentTest :
             val httpClient =
                 httpClient {
                     configureMockEngineHappy(
-                        expectedPath = "/assets/users/123/-/content/entry/1",
+                        expectedPath = "/assets/users/123/-/entry/1/content",
                         bytes = imageBytes,
                     )
                 }
@@ -153,7 +153,7 @@ class KoniferClientContentTest :
                     responseChannel.toByteArray()
                 }
             val response =
-                koniferClient.getAssetContent(
+                koniferClient.fetchAssetContent(
                     path = "/users/123",
                     byteChannel = responseChannel,
                     querySelectors = QuerySelectors.EntryId(1),
@@ -168,7 +168,7 @@ class KoniferClientContentTest :
             val httpClient =
                 httpClient {
                     configureMockEngineHappy(
-                        expectedPath = "/assets/users/123/-/content/modified",
+                        expectedPath = "/assets/users/123/-/modified/content",
                         bytes = imageBytes,
                     )
                 }
@@ -181,7 +181,7 @@ class KoniferClientContentTest :
                     responseChannel.toByteArray()
                 }
             val response =
-                koniferClient.getAssetContent(
+                koniferClient.fetchAssetContent(
                     path = "/users/123",
                     byteChannel = responseChannel,
                     querySelectors = QuerySelectors.OrderBy(Order.MODIFIED),
@@ -206,7 +206,7 @@ class KoniferClientContentTest :
 
             val byteChannel = ByteChannel()
             val response =
-                koniferClient.getAssetContent(
+                koniferClient.fetchAssetContent(
                     path = "/users/123",
                     byteChannel = byteChannel,
                     requestedTransformation = requestedTransformation {},
@@ -234,7 +234,7 @@ class KoniferClientContentTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetContentBytes(
+                koniferClient.fetchAssetContentBytes(
                     path = "/users/123",
                     requestedTransformation = requestedTransformation {},
                 )
@@ -264,7 +264,7 @@ class KoniferClientContentTest :
                     responseChannel.toByteArray()
                 }
             val response =
-                koniferClient.getAssetContent(
+                koniferClient.fetchAssetContent(
                     path = "/users/123",
                     byteChannel = responseChannel,
                     querySelectors = QuerySelectors.None(),

--- a/client/src/commonTest/kotlin/io/konifer/client/link/KoniferClientLinkTest.kt
+++ b/client/src/commonTest/kotlin/io/konifer/client/link/KoniferClientLinkTest.kt
@@ -6,7 +6,6 @@ import io.konifer.client.harness.allTransformationsDsl
 import io.konifer.client.harness.configureMockEngineError
 import io.konifer.client.harness.createErrorResponse
 import io.konifer.client.harness.httpClient
-import io.konifer.client.requestedTransformation
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
@@ -26,7 +25,7 @@ class KoniferClientLinkTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetLink(
+                koniferClient.fetchAssetLink(
                     path = "/users/123",
                 )
             response::class shouldBe KoniferResponse.Success::class
@@ -47,7 +46,7 @@ class KoniferClientLinkTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetLink(
+                koniferClient.fetchAssetLink(
                     path = "/users/123",
                 )
             response::class shouldBe KoniferResponse.HttpError::class
@@ -68,7 +67,7 @@ class KoniferClientLinkTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetLink(
+                koniferClient.fetchAssetLink(
                     path = "/users/123",
                     requestedTransformation = allTransformationsDsl,
                 )

--- a/client/src/commonTest/kotlin/io/konifer/client/metadata/KoniferClientLimitMetadataTest.kt
+++ b/client/src/commonTest/kotlin/io/konifer/client/metadata/KoniferClientLimitMetadataTest.kt
@@ -31,7 +31,7 @@ class KoniferClientLimitMetadataTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetMetadata(
+                koniferClient.fetchAssetMetadata(
                     path = "/users/123",
                     limit = 2,
                 )
@@ -48,7 +48,7 @@ class KoniferClientLimitMetadataTest :
             val httpClient =
                 httpClient {
                     configureMockEngineHappy(
-                        expectedPath = "/assets/users/123/-/metadata/new",
+                        expectedPath = "/assets/users/123/-/new/metadata",
                         response = serverResponse,
                     )
                 }
@@ -56,7 +56,7 @@ class KoniferClientLimitMetadataTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetMetadata(
+                koniferClient.fetchAssetMetadata(
                     path = "/users/123",
                     querySelectors = QuerySelectors.OrderBy(Order.NEW),
                     limit = 2,
@@ -74,7 +74,7 @@ class KoniferClientLimitMetadataTest :
             val httpClient =
                 httpClient {
                     configureMockEngineHappy(
-                        expectedPath = "/assets/users/123/-/metadata/entry/1",
+                        expectedPath = "/assets/users/123/-/entry/1/metadata",
                         response = serverResponse,
                     )
                 }
@@ -82,7 +82,7 @@ class KoniferClientLimitMetadataTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetMetadata(
+                koniferClient.fetchAssetMetadata(
                     path = "/users/123",
                     querySelectors = QuerySelectors.EntryId(1),
                     limit = 2,
@@ -105,7 +105,7 @@ class KoniferClientLimitMetadataTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetMetadata(
+                koniferClient.fetchAssetMetadata(
                     path = "/users/123",
                     limit = 2,
                 )

--- a/client/src/commonTest/kotlin/io/konifer/client/metadata/KoniferClientSingleMetadataTest.kt
+++ b/client/src/commonTest/kotlin/io/konifer/client/metadata/KoniferClientSingleMetadataTest.kt
@@ -33,7 +33,7 @@ class KoniferClientSingleMetadataTest :
 
             val koniferClient = KoniferClient(httpClient)
 
-            val response = koniferClient.getAssetMetadata("/users/123")
+            val response = koniferClient.fetchAssetMetadata("/users/123")
             response::class shouldBe KoniferResponse.Success::class
             (response as KoniferResponse.Success<*>).body shouldBe serverResponse
         }
@@ -42,7 +42,7 @@ class KoniferClientSingleMetadataTest :
             val serverResponse = createMetadataResponse()
             val mockEngine =
                 configureMockEngineHappy(
-                    expectedPath = "/assets/users/123/-/metadata/new",
+                    expectedPath = "/assets/users/123/-/new/metadata",
                     response = serverResponse,
                 )
             val httpClient =
@@ -54,7 +54,7 @@ class KoniferClientSingleMetadataTest :
 
             val koniferClient = KoniferClient(httpClient)
 
-            val response = koniferClient.getAssetMetadata("/users/123", QuerySelectors.OrderBy(Order.NEW))
+            val response = koniferClient.fetchAssetMetadata("/users/123", QuerySelectors.OrderBy(Order.NEW))
             response::class shouldBe KoniferResponse.Success::class
             (response as KoniferResponse.Success<*>).body shouldBe serverResponse
         }
@@ -63,7 +63,7 @@ class KoniferClientSingleMetadataTest :
             val serverResponse = createMetadataResponse()
             val mockEngine =
                 configureMockEngineHappy(
-                    expectedPath = "/assets/users/123/-/metadata/entry/1",
+                    expectedPath = "/assets/users/123/-/entry/1/metadata",
                     response = serverResponse,
                 )
             val httpClient =
@@ -75,7 +75,7 @@ class KoniferClientSingleMetadataTest :
 
             val koniferClient = KoniferClient(httpClient)
 
-            val response = koniferClient.getAssetMetadata("/users/123", QuerySelectors.EntryId(1))
+            val response = koniferClient.fetchAssetMetadata("/users/123", QuerySelectors.EntryId(1))
             response::class shouldBe KoniferResponse.Success::class
             (response as KoniferResponse.Success<*>).body shouldBe serverResponse
         }
@@ -97,7 +97,7 @@ class KoniferClientSingleMetadataTest :
 
             val koniferClient = KoniferClient(httpClient)
 
-            val response = koniferClient.getAssetMetadata("/users/123")
+            val response = koniferClient.fetchAssetMetadata("/users/123")
             response::class shouldBe KoniferResponse.HttpError::class
             with(response as KoniferResponse.HttpError) {
                 message shouldBe serverResponse.message

--- a/client/src/commonTest/kotlin/io/konifer/client/redirect/KoniferClientRedirectLocationTest.kt
+++ b/client/src/commonTest/kotlin/io/konifer/client/redirect/KoniferClientRedirectLocationTest.kt
@@ -6,7 +6,6 @@ import io.konifer.client.harness.allTransformationsDsl
 import io.konifer.client.harness.configureMockEngineError
 import io.konifer.client.harness.createErrorResponse
 import io.konifer.client.harness.httpClient
-import io.konifer.client.requestedTransformation
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.ktor.http.HttpStatusCode
@@ -27,7 +26,7 @@ class KoniferClientRedirectLocationTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetRedirectLocation(
+                koniferClient.fetchAssetRedirectLocation(
                     path = "/users/123",
                 )
             response::class shouldBe KoniferResponse.Success::class
@@ -48,7 +47,7 @@ class KoniferClientRedirectLocationTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetRedirectLocation(
+                koniferClient.fetchAssetRedirectLocation(
                     path = "/users/123",
                 )
             response::class shouldBe KoniferResponse.HttpError::class
@@ -71,7 +70,7 @@ class KoniferClientRedirectLocationTest :
             val koniferClient = KoniferClient(httpClient)
 
             val response =
-                koniferClient.getAssetRedirectLocation(
+                koniferClient.fetchAssetRedirectLocation(
                     path = "/users/123",
                     requestedTransformation = allTransformationsDsl,
                 )

--- a/client/src/jvmMain/kotlin/io/konifer/client/KoniferBlockingClient.kt
+++ b/client/src/jvmMain/kotlin/io/konifer/client/KoniferBlockingClient.kt
@@ -21,7 +21,7 @@ class KoniferBlockingClient(
         querySelectors: QuerySelectors = QuerySelectors.None(),
     ): KoniferResponse<AssetResponse> =
         runBlocking {
-            client.getAssetMetadata(
+            client.fetchAssetMetadata(
                 path = path,
                 querySelectors = querySelectors,
             )
@@ -33,7 +33,7 @@ class KoniferBlockingClient(
         querySelectors: QuerySelectors = QuerySelectors.None(),
     ): KoniferResponse<List<AssetResponse>> =
         runBlocking {
-            client.getAssetMetadata(
+            client.fetchAssetMetadata(
                 path = path,
                 limit = limit,
                 querySelectors = querySelectors,
@@ -52,7 +52,7 @@ class KoniferBlockingClient(
                     byteChannel.copyTo(outputStream)
                 }
             val response =
-                client.getAssetContent(
+                client.fetchAssetContent(
                     path = path,
                     querySelectors = options.querySelectors,
                     requestedTransformation = options.requestedTransformation,
@@ -74,7 +74,7 @@ class KoniferBlockingClient(
         requestedTransformation: RequestedTransformation = RequestedTransformation.OriginalVariant,
     ): KoniferResponse<String> =
         runBlocking {
-            client.getAssetRedirectLocation(
+            client.fetchAssetRedirectLocation(
                 path = path,
                 querySelectors = querySelectors,
                 requestedTransformation = requestedTransformation,
@@ -86,7 +86,7 @@ class KoniferBlockingClient(
         options: AssetContentRequestOptions,
     ): KoniferResponse<ByteArray> =
         runBlocking {
-            client.getAssetContentBytes(
+            client.fetchAssetContentBytes(
                 path = path,
                 querySelectors = options.querySelectors,
                 requestedTransformation = options.requestedTransformation,
@@ -100,7 +100,7 @@ class KoniferBlockingClient(
         requestedTransformation: RequestedTransformation = RequestedTransformation.OriginalVariant,
     ): KoniferResponse<AssetLinkResponse> =
         runBlocking {
-            client.getAssetLink(
+            client.fetchAssetLink(
                 path = path,
                 querySelectors = querySelectors,
                 requestedTransformation = requestedTransformation,

--- a/client/src/jvmTest/kotlin/io/konifer/client/KoniferBlockingClientTest.kt
+++ b/client/src/jvmTest/kotlin/io/konifer/client/KoniferBlockingClientTest.kt
@@ -37,7 +37,7 @@ class KoniferBlockingClientTest :
             val httpClient =
                 httpClient {
                     configureMockMetadataEngineHappy(
-                        expectedPath = "/assets/users/123/-/metadata/modified",
+                        expectedPath = "/assets/users/123/-/modified/metadata",
                         response = expectedResponse,
                     )
                 }
@@ -87,7 +87,7 @@ class KoniferBlockingClientTest :
             val httpClient =
                 httpClient {
                     configureMockEngineHappyRedirect(
-                        expectedPath = "/assets/users/123/-/redirect/entry/1",
+                        expectedPath = "/assets/users/123/-/entry/1/redirect",
                         bytes = imageBytes,
                         requestedTransformation = requestedTransformation,
                     )
@@ -144,7 +144,7 @@ class KoniferBlockingClientTest :
             val httpClient =
                 httpClient {
                     configureMockRedirectLocationEngineHappy(
-                        expectedPath = "/assets/users/123/-/redirect/entry/7",
+                        expectedPath = "/assets/users/123/-/entry/7/redirect",
                         redirectLocation = redirectLocation,
                         requestedTransformation = requestedTransformation,
                     )

--- a/service/src/functionalTest/kotlin/io/konifer/asset/StoreAssetTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/StoreAssetTest.kt
@@ -141,7 +141,7 @@ class StoreAssetTest : BaseFunctionalTest() {
                         byteChannel.close()
                     }
                 }
-            konifer.getAssetContent(
+            konifer.fetchAssetContent(
                 path = "users/123/profile",
                 byteChannel = byteChannel,
                 fetchMode = ContentFetchMode.CONTENT,

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/EagerVariantTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/EagerVariantTest.kt
@@ -64,7 +64,7 @@ class EagerVariantTest : BaseFunctionalTest() {
                         await().untilCallTo {
                             runBlocking {
                                 val response =
-                                    konifer.getAssetMetadata(
+                                    konifer.fetchAssetMetadata(
                                         path = "users/123",
                                     )
                                 (response as KoniferResponse.Success).body.variants.size
@@ -72,7 +72,7 @@ class EagerVariantTest : BaseFunctionalTest() {
                         } matches { count -> count == 3 }
 
                         val response =
-                            konifer.getAssetMetadata(
+                            konifer.fetchAssetMetadata(
                                 path = "users/123",
                             )
                         val variants = (response as KoniferResponse.Success).body.variants
@@ -206,7 +206,7 @@ class EagerVariantTest : BaseFunctionalTest() {
                             bytes = image,
                         )::class shouldBe KoniferResponse.Success::class
                         konifer
-                            .getAssetContentBytes(
+                            .fetchAssetContentBytes(
                                 path = "apple/123",
                                 requestedTransformation =
                                     requestedTransformation {

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/FetchAssetVariantTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/FetchAssetVariantTest.kt
@@ -53,7 +53,7 @@ class FetchAssetVariantTest : BaseFunctionalTest() {
                 )
 
             val response =
-                konifer.getAssetContentBytes(
+                konifer.fetchAssetContentBytes(
                     path = "users/123",
                     requestedTransformation =
                         requestedTransformation {
@@ -64,7 +64,7 @@ class FetchAssetVariantTest : BaseFunctionalTest() {
             response.body shouldBeFormat ImageFormat.JPEG
 
             konifer
-                .getAssetMetadata(
+                .fetchAssetMetadata(
                     path = "users/123",
                 ).fold(
                     onSuccess = { response ->
@@ -93,7 +93,7 @@ class FetchAssetVariantTest : BaseFunctionalTest() {
                 )
 
             konifer
-                .getAssetContentBytes(
+                .fetchAssetContentBytes(
                     path = "users/123",
                     requestedTransformation =
                         requestedTransformation {
@@ -131,7 +131,7 @@ class FetchAssetVariantTest : BaseFunctionalTest() {
                 )
 
             konifer
-                .getAssetContentBytes(
+                .fetchAssetContentBytes(
                     path = "users/123",
                     requestedTransformation =
                         requestedTransformation {


### PR DESCRIPTION
Also renamed methods to align with Konifer's API nomenclature 