### PR TITLE
Apply path configuration at path root when path is configured with wildcard

### DIFF
--- a/integration-test/src/test/kotlin/integration/ColorspaceConversionIntegrationTest.kt
+++ b/integration-test/src/test/kotlin/integration/ColorspaceConversionIntegrationTest.kt
@@ -4,8 +4,8 @@ import io.konifer.client.KoniferResponse
 import io.konifer.client.requestedTransformation
 import io.konifer.common.http.StoreAssetRequest
 import io.konifer.common.image.TransformableColorSpace
-import io.kotest.engine.runBlocking
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
 import org.apache.tika.Tika
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
@@ -19,18 +19,16 @@ class ColorspaceConversionIntegrationTest : BaseIntegrationTest() {
         runBlocking {
             val path = UUID.randomUUID().toString()
             val (image, attributes) = ImageFactory.testImage()
-            val storeResponse = runBlocking {
-                client.storeAsset(
-                    path = path,
-                    format = attributes.format,
-                    bytes = image,
-                    request = StoreAssetRequest(
-                        alt = "image",
-                        tags = setOf("tag1", "tag2"),
-                        labels = mapOf("key1" to "value1", "key2" to "value2")
-                    )
+            val storeResponse = client.storeAsset(
+                path = path,
+                format = attributes.format,
+                bytes = image,
+                request = StoreAssetRequest(
+                    alt = "image",
+                    tags = setOf("tag1", "tag2"),
+                    labels = mapOf("key1" to "value1", "key2" to "value2")
                 )
-            }
+            )
             storeResponse::class shouldBe KoniferResponse.Success::class
             val fetchResponse = client.fetchAssetContentBytes(
                 path = path,
@@ -42,6 +40,5 @@ class ColorspaceConversionIntegrationTest : BaseIntegrationTest() {
             val content = (fetchResponse as KoniferResponse.Success).body
             Tika().detect(content) shouldBe attributes.format.mimeType
         }
-
     }
 }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/DeleteAssetTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/DeleteAssetTest.kt
@@ -11,7 +11,6 @@ import io.konifer.common.selector.Order
 import io.konifer.matchers.shouldBeSuccessful
 import io.konifer.matchers.shouldHaveHttpError
 import io.konifer.testInMemory
-import io.konifer.util.deleteAsset
 import io.konifer.util.fetchAssetMetadata
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.delete

--- a/service/src/functionalTest/kotlin/io/konifer/util/AssetTestUtils.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/util/AssetTestUtils.kt
@@ -5,7 +5,6 @@ import io.konifer.common.http.AssetResponse
 import io.konifer.common.http.StoreAssetRequest
 import io.konifer.common.image.ImageFormat
 import io.konifer.common.selector.Order
-import io.konifer.common.selector.ReturnFormat
 import io.konifer.domain.image.fromFormat
 import io.konifer.infrastructure.http.APP_CACHE_STATUS
 import io.kotest.matchers.collections.shouldHaveSize
@@ -17,7 +16,6 @@ import io.kotest.matchers.string.shouldBeEqualIgnoringCase
 import io.kotest.matchers.string.shouldContain
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.delete
 import io.ktor.client.request.forms.MultiPartFormDataContent
 import io.ktor.client.request.forms.formData
 import io.ktor.client.request.get
@@ -439,7 +437,7 @@ suspend fun fetchAssetLink(
         headers[HttpHeaders.Location] shouldBe null
         headers[HttpHeaders.ETag] shouldBe null
         return if (expectedStatusCode == HttpStatusCode.OK) {
-            contentType() shouldBe ContentType.parse("application/json; charset=UTF-8")
+            contentType()?.contentType shouldBe ContentType.Application.Json.contentType
 
             if (expectCacheHit == true) {
                 headers[APP_CACHE_STATUS] shouldBeEqualIgnoringCase "hit"
@@ -453,25 +451,6 @@ suspend fun fetchAssetLink(
             }
         } else {
             null
-        }
-    }
-}
-
-suspend fun assertAssetDoesNotExist(
-    client: HttpClient,
-    path: String = "profile",
-    entryId: Long? = null,
-) {
-    ReturnFormat.entries.forEach { format ->
-        val urlBuilder = URLBuilder()
-        if (entryId != null) {
-            urlBuilder.path("/assets/$path/-/${format.name}/entry/$entryId")
-        } else {
-            urlBuilder.path("/assets/$path/-/${format.name}")
-        }
-        client.get(urlBuilder.build()).apply {
-            status shouldBe HttpStatusCode.NotFound
-            headers.contains(HttpHeaders.Location) shouldBe false
         }
     }
 }
@@ -535,50 +514,6 @@ suspend fun fetchAllAssetMetadata(
     } else {
         response.body<List<AssetResponse>>()
     }
-}
-
-suspend fun deleteAsset(
-    client: HttpClient,
-    path: String = "profile",
-    entryId: Long? = null,
-    expectedStatusCode: HttpStatusCode = HttpStatusCode.NoContent,
-) {
-    if (entryId != null) {
-        client.delete("/assets/$path/-/entry/$entryId").status shouldBe expectedStatusCode
-    } else {
-        client.delete("/assets/$path").status shouldBe expectedStatusCode
-    }
-}
-
-suspend fun deleteAssetsAtPath(
-    client: HttpClient,
-    path: String = "profile",
-    labels: Map<String, String> = emptyMap(),
-    order: Order = Order.NEW,
-    limit: Int = 1,
-    expectedStatusCode: HttpStatusCode = HttpStatusCode.NoContent,
-) {
-    val urlBuilder = URLBuilder()
-    urlBuilder.path("/assets/$path/-/$order")
-    labels.forEach { label ->
-        urlBuilder.parameters.append(label.key, label.value)
-    }
-    urlBuilder.parameters.append("limit", limit.toString())
-    client.delete(urlBuilder.build()).status shouldBe expectedStatusCode
-}
-
-suspend fun deleteAssetsRecursivelyAtPath(
-    client: HttpClient,
-    path: String = "profile",
-    labels: Map<String, String> = emptyMap(),
-    expectedStatusCode: HttpStatusCode = HttpStatusCode.NoContent,
-) {
-    val urlBuilder = URLBuilder()
-    urlBuilder.path("/assets/$path/-/recursive")
-    labels.forEach { label ->
-        urlBuilder.parameters.append(label.key, label.value)
-    }
-    client.delete(urlBuilder.build()).status shouldBe expectedStatusCode
 }
 
 suspend fun updateAsset(

--- a/service/src/main/kotlin/io/konifer/infrastructure/path/PathTrieNode.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/path/PathTrieNode.kt
@@ -5,6 +5,7 @@ import io.konifer.domain.path.PathConfiguration
 data class PathTrieNode(
     val segment: String,
     var config: PathConfiguration,
+    var hasExplicitConfiguration: Boolean = false,
     val children: MutableMap<String, PathTrieNode> = mutableMapOf(),
 ) {
     fun getOrCreateChild(

--- a/service/src/main/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepository.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepository.kt
@@ -78,6 +78,7 @@ class TriePathConfigurationRepository(
             current = current.getOrCreateChild(segment, current.config)
         }
         current.config = PathConfiguration.create(applicationConfig, current.config)
+        current.hasExplicitConfiguration = true
     }
 
     private fun matchRecursive(
@@ -87,6 +88,21 @@ class TriePathConfigurationRepository(
     ): MatchResult {
         // Base case
         if (segments.isEmpty()) {
+            if (node.hasExplicitConfiguration) {
+                return MatchResult(node, depth)
+            }
+
+            val candidates = mutableListOf<MatchResult>()
+
+            node.children[WILDCARD_SEGMENT]?.let { wildcard ->
+                candidates += matchRecursive(wildcard, emptyList(), depth + 1)
+            }
+
+            node.children[GREEDY_WILDCARD_SEGMENT]?.let { greedy ->
+                candidates += matchRecursive(greedy, emptyList(), depth + 1)
+            }
+
+            candidates.maxByOrNull { it.depth }?.let { return it }
             return MatchResult(node, depth)
         }
 

--- a/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
@@ -359,4 +359,204 @@ class TriePathConfigurationRepositoryTest {
         val pathConfiguration = pathConfigurationRepository.fetch("/profile/123")
         pathConfiguration.eagerVariants shouldBe listOf("large")
     }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["/", "/profile/", "/profile/123/"])
+    fun `configuration under wildcard is applied at the root of the path`(path: String) {
+        val config =
+            """
+            paths = [
+              {
+                path = "$path*"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+        val pathConfigurationRepository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+        val pathConfiguration = pathConfigurationRepository.fetch(path)
+        pathConfiguration.eagerVariants shouldBe listOf("large")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["/", "/profile/", "/profile/123/"])
+    fun `configuration under greedy wildcard is applied at the root of the path`(path: String) {
+        val config =
+            """
+            paths = [
+              {
+                path = "$path**"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+        val pathConfigurationRepository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+        val pathConfiguration = pathConfigurationRepository.fetch(path)
+        pathConfiguration.eagerVariants shouldBe listOf("large")
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["/profile", "/profile/123"])
+    fun `wildcard wins over greedy wildcard specified on same path`(path: String) {
+        val config =
+            """
+            paths = [
+              {
+                path = "/profile/*"
+                eager-variants = [medium]
+              }
+              {
+                path = "/profile/**"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+        val pathConfigurationRepository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+        val pathConfiguration = pathConfigurationRepository.fetch(path)
+        pathConfiguration.eagerVariants shouldBe listOf("medium")
+    }
+
+    @Test
+    fun `exact path wins over wildcard on same path`() {
+        val config =
+            """
+            paths = [
+              {
+                path = "/profile/123"
+                eager-variants = [small]
+              },
+              {
+                path = "/profile/*"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+
+        val repository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+
+        repository.fetch("/profile/123").eagerVariants shouldBe listOf("small")
+    }
+
+    @Test
+    fun `exact path wins over greedy wildcard on same path`() {
+        val config =
+            """
+            paths = [
+              {
+                path = "/profile/123"
+                eager-variants = [small]
+              },
+              {
+                path = "/profile/**"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+
+        val repository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+
+        repository.fetch("/profile/123").eagerVariants shouldBe listOf("small")
+    }
+
+    @Test
+    fun `explicit parent path wins over wildcard child when fetching parent path`() {
+        val config =
+            """
+            paths = [
+              {
+                path = "/profile"
+                eager-variants = [small]
+              },
+              {
+                path = "/profile/*"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+
+        val repository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+
+        repository.fetch("/profile").eagerVariants shouldBe listOf("small")
+    }
+
+    @Test
+    fun `greedy wildcard can consume zero segments before matching following segment`() {
+        val config =
+            """
+            paths = [
+              {
+                path = "/users/**/profile"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+
+        val repository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+
+        repository.fetch("/users/profile").eagerVariants shouldBe listOf("large")
+    }
+
+    @Test
+    fun `deeper greedy wildcard match wins over shallower greedy wildcard match`() {
+        val config =
+            """
+            paths = [
+              {
+                path = "/users/**"
+                eager-variants = [small]
+              },
+              {
+                path = "/users/**/profile"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+
+        val repository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+
+        repository.fetch("/users/123/profile").eagerVariants shouldBe listOf("large")
+    }
+
+    @Test
+    fun `configured path is stripped of blank and empty path segments`() {
+        val config =
+            """
+            paths = [
+              {
+                path = "//profile//*/"
+                eager-variants = [large]
+              }
+            ]
+            """.trimIndent()
+
+        val repository =
+            TriePathConfigurationRepository(
+                HoconApplicationConfig(ConfigFactory.parseString(config)),
+            )
+
+        repository.fetch("/profile/123").eagerVariants shouldBe listOf("large")
+    }
 }


### PR DESCRIPTION
If someone has path config for: `/profile/*` or `/profile/**`, they should have that config applied for assets stored on `/profile`