### PR TITLE
Migrate to Koin compiler plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,7 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.license)
     alias(libs.plugins.kover)
+    alias(libs.plugins.koin.compiler)
 }
 
 group = "io.konifer"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 jooq-version = "3.21.4"
 koin-version = "4.2.1"
+koin-plugin-version = "1.0.0"
 kotlin-version = "2.3.21"
 ktlint-version = "14.2.0"
 ktor-version = "3.5.0"
@@ -21,7 +22,6 @@ kotlin-coroutine-reactive-version = "1.10.2"
 db-scheduler-version = "16.7.1"
 hikari-version = "7.0.2"
 uuid-creator-version = "6.1.1"
-bytebuddy-version = "1.18.3"
 commons-codec-version = "1.22.0"
 detekt-version = "2.0.0-alpha.2"
 license-version = "3.1.2"
@@ -115,3 +115,4 @@ license = { id = "com.github.jk1.dependency-license-report", version.ref = "lice
 google-devtools-ksp = { id = "com.google.devtools.ksp", version.ref = "google-devtools-ksp-version" }
 kotest = { id = "io.kotest", version.ref = "kotest-version" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover-version" }
+koin-compiler = { id = "io.insert-koin.compiler.plugin", version.ref = "koin-plugin-version" }

--- a/service/build.gradle.kts
+++ b/service/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.kover)
+    alias(libs.plugins.koin.compiler)
     `java-test-fixtures`
 }
 
@@ -142,20 +143,6 @@ dependencies {
     "functionalTestImplementation"(testFixtures(project))
     "functionalTestImplementation"(project(":common"))
     "functionalTestImplementation"(project(":client"))
-}
-
-/**
- * Necessary for Java 25 support - hopefully this can go away when ktor BOM supports Java 25
- */
-configurations.all {
-    resolutionStrategy {
-        val bytebuddyVersion =
-            libs.versions.bytebuddy.version
-                .get()
-
-        force("net.bytebuddy:byte-buddy:$bytebuddyVersion")
-        force("net.bytebuddy:byte-buddy-agent:$bytebuddyVersion")
-    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/service/src/main/kotlin/io/konifer/domain/context/RequestContextFactory.kt
+++ b/service/src/main/kotlin/io/konifer/domain/context/RequestContextFactory.kt
@@ -83,26 +83,27 @@ class RequestContextFactory(
                 path = segments.getOrNull(1),
                 parameters = queryParameters,
             )
-        val requestedImageAttributes =
+        val requestedTransformation =
             extractRequestedImageTransformation(
                 querySelectors = querySelectors,
                 headers = headers,
                 parameters = queryParameters,
             )
+        val pathConfiguration = pathConfigurationRepository.fetch(segments.first())
         if (
             querySelectors.returnFormat == ReturnFormat.METADATA &&
-            requestedImageAttributes != null &&
-            !requestedImageAttributes.originalVariant
+            requestedTransformation != null &&
+            !requestedTransformation.originalVariant
         ) {
             throw InvalidPathException("Cannot specify image attributes when requesting asset metadata")
         }
 
         return QueryRequestContext(
             path = segments.first(),
-            pathConfiguration = pathConfigurationRepository.fetch(segments[0]),
+            pathConfiguration = pathConfiguration,
             selectors = querySelectors,
             transformation =
-                requestedImageAttributes?.let {
+                requestedTransformation?.let {
                     transformationNormalizer.normalize(
                         treePath = segments.first(),
                         entryId = querySelectors.entryId,

--- a/service/src/main/kotlin/io/konifer/entrypoint/AssetRoutes.kt
+++ b/service/src/main/kotlin/io/konifer/entrypoint/AssetRoutes.kt
@@ -233,26 +233,26 @@ suspend fun storeNewAsset(
                                     part.provider().copyTo(assetContentChannel)
                                 } finally {
                                     assetContentChannel.close()
-                                    part.dispose()
+                                    part.release()
                                 }
                             is PartData.BinaryChannelItem ->
                                 try {
                                     part.provider().copyTo(assetContentChannel)
                                 } finally {
                                     assetContentChannel.close()
-                                    part.dispose()
+                                    part.release()
                                 }
                             is PartData.BinaryItem ->
                                 try {
                                     part.provider().transferTo(assetContentChannel.asSink())
                                 } finally {
                                     assetContentChannel.close()
-                                    part.dispose()
+                                    part.release()
                                 }
-                            else -> part.dispose()
+                            else -> part.release()
                         }
                     }
-                    else -> part.dispose()
+                    else -> part.release()
                 }
             }
 

--- a/service/src/main/kotlin/io/konifer/infrastructure/KtorKoin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/KtorKoin.kt
@@ -14,7 +14,7 @@ import io.konifer.domain.transformation.TransformationNormalizer
 import io.konifer.domain.variant.VariantService
 import io.konifer.infrastructure.asset.assetContainerFactoryModule
 import io.konifer.infrastructure.datastore.assetRepositoryModule
-import io.konifer.infrastructure.e.InMemoryEventBus
+import io.konifer.infrastructure.event.InMemoryEventBus
 import io.konifer.infrastructure.http.httpClientModule
 import io.konifer.infrastructure.http.httpModule
 import io.konifer.infrastructure.objectstore.ObjectStoreProvider
@@ -29,9 +29,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.bind
+import org.koin.core.module.dsl.createdAtStart
+import org.koin.core.module.dsl.singleOf
+import org.koin.core.module.dsl.withOptions
 import org.koin.dsl.module
 import org.koin.ktor.plugin.Koin
 import org.koin.logger.slf4jLogger
+import org.koin.plugin.module.dsl.single
 
 fun Application.configureKoin(
     objectStoreProvider: ObjectStoreProvider,
@@ -58,48 +63,25 @@ fun Application.configureKoin(
 
 fun domainModule(): Module =
     module {
-        single<RequestContextFactory> {
-            RequestContextFactory(get(), get(), get())
+        single<RequestContextFactory>()
+        single<TransformationNormalizer>()
+        single<VariantService>()
+        singleOf(::InMemoryEventBus) {
+            bind<EventPublisher>()
+            bind<EventBus>()
         }
-        single<TransformationNormalizer> {
-            TransformationNormalizer(get())
-        }
-        single<VariantService> {
-            VariantService(get(), get(), get(), get())
-        }
-
-        val eventBus = InMemoryEventBus()
-        single<EventPublisher> {
-            eventBus
-        }
-        single<EventBus> {
-            eventBus
-        }
-
-        single<FormatValidator> {
-            FormatValidator(get())
-        }
+        single<FormatValidator>()
     }
 
 fun appModule(): Module =
     module {
-        single<FetchAssetHandler> {
-            FetchAssetHandler(get(), get(), get(), get())
-        }
-        single<DeleteAssetUseCase> {
-            DeleteAssetUseCase(get())
-        }
-        single<UpdateAssetUseCase> {
-            UpdateAssetUseCase(get())
-        }
-        single<StoreNewAssetUseCase> {
-            StoreNewAssetUseCase(get(), get(), get(), get(), get(), get(), get())
-        }
-        single<VariantProcessorPipeline> {
-            VariantProcessorPipeline(get(), get())
-        }
+        single<FetchAssetHandler>()
+        single<DeleteAssetUseCase>()
+        single<UpdateAssetUseCase>()
+        single<StoreNewAssetUseCase>()
+        single<VariantProcessorPipeline>()
         single<CoroutineScope> { CoroutineScope(SupervisorJob() + Dispatchers.Default) }
-        single<AssetEventListener>(createdAtStart = true) {
-            AssetEventListener(get(), get(), get(), get())
+        single<AssetEventListener>() withOptions {
+            createdAtStart()
         }
     }

--- a/service/src/main/kotlin/io/konifer/infrastructure/datastore/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/datastore/Koin.kt
@@ -2,7 +2,6 @@ package io.konifer.infrastructure.datastore
 
 import io.konifer.domain.ports.AssetRepository
 import io.konifer.infrastructure.datastore.inmemory.InMemoryAssetRepository
-import io.konifer.infrastructure.datastore.postgres.PostgresAssetRepository
 import io.konifer.infrastructure.datastore.postgres.createPostgresProperties
 import io.konifer.infrastructure.datastore.postgres.postgres
 import io.konifer.infrastructure.datastore.postgres.scheduling.configureScheduling
@@ -18,16 +17,18 @@ import org.jooq.impl.DSL
 import org.jooq.impl.DefaultConfiguration
 import org.jooq.tools.LoggerListener
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.createdAtStart
+import org.koin.core.module.dsl.withOptions
+import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 
 fun Application.assetRepositoryModule(): Module =
     module {
         val datastoreProvider = environment.config.getDataStoreProvider()
         when (datastoreProvider) {
             DataStoreProvider.IN_MEMORY -> {
-                single<AssetRepository>(createdAtStart = true) {
-                    InMemoryAssetRepository()
-                }
+                single<InMemoryAssetRepository>() bind AssetRepository::class
             }
             DataStoreProvider.POSTGRES -> {
                 val properties = createPostgresProperties()
@@ -35,14 +36,10 @@ fun Application.assetRepositoryModule(): Module =
                 migrateSchema(connectionFactory)
                 val dslContext = configureR2dbcJOOQ(connectionFactory)
                 configureScheduling(properties, dslContext)
-                single<ConnectionFactory> {
-                    connectionFactory
-                }
-                single<DSLContext>(createdAtStart = true) {
-                    dslContext
-                }
-                single<AssetRepository> {
-                    PostgresAssetRepository(get())
+                single<AssetRepository>()
+                single<ConnectionFactory>()
+                single<DSLContext>() withOptions {
+                    createdAtStart()
                 }
             }
         }

--- a/service/src/main/kotlin/io/konifer/infrastructure/event/InMemoryEventBus.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/event/InMemoryEventBus.kt
@@ -1,4 +1,4 @@
-package io.konifer.infrastructure.e
+package io.konifer.infrastructure.event
 
 import io.konifer.domain.event.DomainEvent
 import io.konifer.domain.ports.EventBus

--- a/service/src/main/kotlin/io/konifer/infrastructure/http/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/http/Koin.kt
@@ -14,6 +14,7 @@ import io.ktor.server.config.tryGetString
 import okhttp3.ConnectionPool
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 import java.util.concurrent.TimeUnit
 
 fun httpClientModule(): Module =
@@ -60,7 +61,5 @@ fun Application.httpModule(): Module =
             )
         }
 
-        single<AssetUrlGenerator> {
-            AssetUrlGenerator(get())
-        }
+        single<AssetUrlGenerator>()
     }

--- a/service/src/main/kotlin/io/konifer/infrastructure/objectstore/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/objectstore/Koin.kt
@@ -25,7 +25,11 @@ import io.ktor.server.application.Application
 import io.ktor.server.config.tryGetString
 import io.ktor.util.logging.KtorSimpleLogger
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.createdAtStart
+import org.koin.core.module.dsl.withOptions
+import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.transfer.s3.S3TransferManager
@@ -39,9 +43,7 @@ fun Application.objectStoreModule(provider: ObjectStoreProvider): Module =
         logger.info("Using object store provider: $provider")
         when (provider) {
             ObjectStoreProvider.IN_MEMORY -> {
-                single<ObjectStore>(createdAtStart = true) {
-                    InMemoryObjectStore()
-                }
+                single<InMemoryObjectStore>() bind ObjectStore::class
             }
             ObjectStoreProvider.S3 -> {
                 val s3ConfigurationProperties = objectStoreConfig?.tryGetConfig(S3)
@@ -57,18 +59,20 @@ fun Application.objectStoreModule(provider: ObjectStoreProvider): Module =
                         region = s3ConfigurationProperties?.tryGetString(REGION),
                         forcePathStyle = s3ConfigurationProperties?.tryGetString(FORCE_PATH_STYLE)?.toBoolean() ?: false,
                     )
-                single<S3AsyncClient>(createdAtStart = true) {
+                single<S3AsyncClient> {
                     s3Client(s3ClientProperties)
+                } withOptions {
+                    createdAtStart()
                 }
-                single<S3TransferManager>(createdAtStart = true) {
+                single<S3TransferManager> {
                     s3TransferManager(get())
+                } withOptions {
+                    createdAtStart()
                 }
                 single<S3Presigner> {
                     s3Presigner(s3ClientProperties)
                 }
-                single<ObjectStore> {
-                    S3ObjectStore(get(), get(), get())
-                }
+                single<S3ObjectStore>() bind ObjectStore::class
             }
             ObjectStoreProvider.FILESYSTEM -> {
                 val fileSystemProperties = objectStoreConfig?.tryGetConfig(FILESYSTEM)

--- a/service/src/main/kotlin/io/konifer/infrastructure/tika/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/tika/Koin.kt
@@ -2,11 +2,11 @@ package io.konifer.infrastructure.tika
 
 import io.konifer.domain.ports.MimeTypeDetector
 import org.koin.core.module.Module
+import org.koin.dsl.bind
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 
 fun mimeTypeDetectorModule(): Module =
     module {
-        single<MimeTypeDetector> {
-            TikaMimeTypeDetector()
-        }
+        single<TikaMimeTypeDetector>() bind MimeTypeDetector::class
     }

--- a/service/src/main/kotlin/io/konifer/infrastructure/variant/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/variant/Koin.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.channels.Channel
 import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 
 fun Application.variantModule(): Module =
     module {

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/Koin.kt
@@ -2,10 +2,9 @@ package io.konifer.infrastructure.vips
 
 import org.koin.core.module.Module
 import org.koin.dsl.module
+import org.koin.plugin.module.dsl.single
 
 fun vipsModule(): Module =
     module {
-        single<VipsImageProcessor> {
-            VipsImageProcessor()
-        }
+        single<VipsImageProcessor>()
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/InMemoryEventBusTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/InMemoryEventBusTest.kt
@@ -1,0 +1,57 @@
+package io.konifer.infrastructure
+
+import io.konifer.common.image.ImageFormat
+import io.konifer.domain.asset.AssetId
+import io.konifer.domain.event.AssetReadyEvent
+import io.konifer.domain.image.ColorSpace
+import io.konifer.domain.path.PathConfiguration
+import io.konifer.domain.variant.Attributes
+import io.konifer.domain.variant.LQIPs
+import io.konifer.domain.variant.Variant
+import io.konifer.infrastructure.event.InMemoryEventBus
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+class InMemoryEventBusTest {
+    private val bus = InMemoryEventBus()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `when event is published it can be consumed`() =
+        runTest {
+            val counter = AtomicInteger(0)
+
+            // Pass UnconfinedTestDispatcher to launch eagerly
+            val consumer =
+                launch(UnconfinedTestDispatcher(testScheduler)) {
+                    bus.events.collect {
+                        counter.incrementAndGet()
+                    }
+                }
+
+            bus.publish(
+                AssetReadyEvent(
+                    pathConfiguration = PathConfiguration.default,
+                    originalVariantFile = null,
+                    originalVariant =
+                        Variant.Pending.originalVariant(
+                            assetId = AssetId(UUID.randomUUID()),
+                            attributes = Attributes(width = 100, height = 100, format = ImageFormat.JPEG, colorSpace = ColorSpace.SRGB),
+                            objectStoreBucket = "bucket",
+                            objectStoreKey = "key",
+                            lqip = LQIPs.NONE,
+                        ),
+                ),
+            )
+
+            counter.get() shouldBe 1
+            consumer.cancel()
+        }
+}


### PR DESCRIPTION
Not as beneficial as I thought it would be. Apparently you only get the compile-time validation with the use of Koin annotations. I generally dislike annotations for one and to get to supporting them would require a reworking of my module configuration. This is eventually going to be necessary but I'd rather spend my time elsewhere for now.