### PR TITLE
[Breaking] alter path configuration to be keyed off the path regex

### DIFF
--- a/integration-test/src/test/resources/konifer.conf
+++ b/integration-test/src/test/resources/konifer.conf
@@ -30,11 +30,10 @@ variant-profiles = [
   }
 ]
 
-paths = [
-  {
-    path = "/**"
+paths {
+  "/**" {
     object-store {
       bucket = assets
     }
   }
-]
+}

--- a/service/src/functionalTest/kotlin/io/konifer/asset/AssetFilesystemRepositoryTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/AssetFilesystemRepositoryTest.kt
@@ -50,9 +50,8 @@ class AssetFilesystemRepositoryTest : BaseFunctionalTest() {
             http {
               public-url = "https://localhost:9000"
             }
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 image {
                   lqip = [ "thumbhash", "blurhash" ]
                 }
@@ -60,7 +59,7 @@ class AssetFilesystemRepositoryTest : BaseFunctionalTest() {
                   bucket = correct-bucket
                 }
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val (image, attributes) = testImage()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetCacheControlTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetCacheControlTest.kt
@@ -14,42 +14,38 @@ class FetchAssetCacheControlTest : BaseFunctionalTest() {
     fun `can fetch assets with cache-control header configured`() =
         testInMemory(
             """
-                paths = [
-                {
-                    path = "/**"
-                    cache-control {
-                        enabled = true
-                        max-age = 50000
-                        visibility = private
-                        immutable = false
-                    }
+            paths {
+              "/**" {
+                cache-control {
+                  enabled = true
+                  max-age = 50000
+                  visibility = private
+                  immutable = false
                 }
-                {
-                    path = "/users/456/*"
-                    cache-control {
-                        revalidate = no-cache
-                    }
+              }
+              "/users/456/*" {
+                cache-control {
+                  revalidate = no-cache
                 }
-                {
-                    path = "/users/123/profile"
-                    cache-control {
-                        enabled = true
-                        max-age = 120000
-                        s-maxage = 230000
-                        visibility = public
-                        revalidate = proxy-revalidate
-                        stale-while-revalidate = 10000
-                        stale-if-error = 300
-                        immutable = true
-                    }
+              }
+              "/users/123/profile" {
+                cache-control {
+                  enabled = true
+                  max-age = 120000
+                  s-maxage = 230000
+                  visibility = public
+                  revalidate = proxy-revalidate
+                  stale-while-revalidate = 10000
+                  stale-if-error = 300
+                  immutable = true
                 }
-                {
-                    path = "/users/999/profile"
-                    cache-control {
-                        enabled = false
-                    }
+              }
+              "/users/999/profile" {
+                cache-control {
+                  enabled = false
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetContentTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetContentTest.kt
@@ -27,14 +27,13 @@ class FetchAssetContentTest : BaseFunctionalTest() {
     fun `can fetch asset and render`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetDownloadTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetDownloadTest.kt
@@ -24,14 +24,13 @@ class FetchAssetDownloadTest : BaseFunctionalTest() {
     fun `can fetch asset and render with return format of download`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -62,14 +61,13 @@ class FetchAssetDownloadTest : BaseFunctionalTest() {
     fun `path is used as filename if alt is not supplied`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetLinkTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetLinkTest.kt
@@ -69,14 +69,13 @@ class FetchAssetLinkTest : BaseFunctionalTest() {
     fun `can fetch asset and render with lqip`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -110,14 +109,13 @@ class FetchAssetLinkTest : BaseFunctionalTest() {
     fun `can fetch variant link and render`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -160,14 +158,13 @@ class FetchAssetLinkTest : BaseFunctionalTest() {
     fun `link preserves all query parameters from original request`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetRedirectTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/FetchAssetRedirectTest.kt
@@ -34,19 +34,18 @@ class FetchAssetRedirectTest : BaseFunctionalTest() {
     fun `can fetch asset and render when redirect mode is template`() =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 return-format {
                   redirect {
                     strategy = template
                     template {
                       string = "https://{bucket}.domain.com/{key}"
                     }
-                  }                
+                  }
                 }
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             configureClient { followRedirects = false }
@@ -71,16 +70,15 @@ class FetchAssetRedirectTest : BaseFunctionalTest() {
     fun `returns content without redirect when redirect strategy is none`() =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 return-format {
                   redirect {
                     strategy = none
                   }
                 }
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             configureClient { followRedirects = false }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/StoreAssetTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/StoreAssetTest.kt
@@ -51,14 +51,13 @@ class StoreAssetTest : BaseFunctionalTest() {
     fun `cannot store asset that is a disallowed content type`() =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/users/*/profile"
+            paths {
+              "/users/*/profile" {
                 allowed-content-types = [
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -79,12 +78,11 @@ class StoreAssetTest : BaseFunctionalTest() {
     fun `cannot store asset if no content type is allowed`() =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/users/*/profile"
+            paths {
+              "/users/*/profile" {
                 allowed-content-types = [ ]
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -105,11 +103,10 @@ class StoreAssetTest : BaseFunctionalTest() {
     fun `can store asset if allowed-content-types is not defined for path`() =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/users/*/profile"
+            paths {
+              "/users/*/profile" {
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -148,20 +145,18 @@ class StoreAssetTest : BaseFunctionalTest() {
     fun `object is stored in configured bucket`() =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 object-store {
                   bucket = default-bucket
                 }
               }
-              {
-                path = "/users/*/profile"
+              "/users/*/profile" {
                 object-store {
                   bucket = correct-bucket
                 }
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -189,9 +184,8 @@ class StoreAssetTest : BaseFunctionalTest() {
     fun `can preprocess image to any every supported type`(format: ImageFormat) =
         testInMemory(
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 preprocessing {
                   enabled = true
                   image {
@@ -199,7 +193,7 @@ class StoreAssetTest : BaseFunctionalTest() {
                   }
                 }
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/EagerVariantTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/EagerVariantTest.kt
@@ -41,12 +41,11 @@ class EagerVariantTest : BaseFunctionalTest() {
                     h = 15
                 }
             ]
-            paths = [
-                {
-                    path = "/users/**"
-                    eager-variants = [small, medium]
-                }
-            ]
+            paths {
+              "/users/**" {
+                eager-variants = [small, medium]
+              }
+            }
             """.trimIndent(),
         ) {
             val (image, attributes) = testImage()
@@ -104,21 +103,19 @@ class EagerVariantTest : BaseFunctionalTest() {
                     h = 15
                 }
             ]
-            paths = [
-                {
-                    path = "/**"
-                    object-store {
-                      bucket = default-bucket
-                    }
+            paths {
+              "/**" {
+                object-store {
+                  bucket = default-bucket
                 }
-                {
-                    path = "/users/**"
-                    eager-variants = [small, medium]
-                    object-store {
-                      bucket = correct-bucket
-                    }
+              }
+              "/users/**" {
+                eager-variants = [small, medium]
+                object-store {
+                  bucket = correct-bucket
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val (image, attributes) = testImage()
@@ -158,18 +155,17 @@ class EagerVariantTest : BaseFunctionalTest() {
                 w = 50
               }
             ]
-            paths = [
-              {
-                path = "/users/**"
+            paths {
+              "/users/**" {
                 eager-variants = [small]
                 preprocessing {
                   enabled = true
                   image {
                     r = 180
                   }
-                }      
+                }
               }
-            ]
+            }
             """.trimIndent(),
         ) {
             val (image, attributes) = testImage()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/FetchAssetVariantTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/FetchAssetVariantTest.kt
@@ -24,20 +24,18 @@ class FetchAssetVariantTest : BaseFunctionalTest() {
     fun `requested asset variants are persisted in configured bucket`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    object-store {
-                      bucket = default-bucket
-                    }
+            paths {
+              "/**" {
+                object-store {
+                  bucket = default-bucket
                 }
-                {
-                    path = "/users/**"
-                    object-store {
-                      bucket = correct-bucket
-                    }
+              }
+              "/users/**" {
+                object-store {
+                  bucket = correct-bucket
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val (image, attributes) = testImage()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImagePreProcessingTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImagePreProcessingTest.kt
@@ -47,17 +47,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `image width is resized when it is too large`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            max-width = 100
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    max-width = 100
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -91,17 +90,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `image height is resized when it is too large`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            max-height = 50
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    max-height = 50
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -140,17 +138,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
         maxHeight: Int?,
     ) = testInMemory(
         """
-        paths = [
-            {
-                path = "/**"
-                preprocessing {
-                    image {
-                        ${maxHeight?.let { "max-height = $it" } ?: ""}
-                        ${maxWidth?.let { "max-width = $it" } ?: ""}
-                    }
-                }
+        paths {
+          "/**" {
+            preprocessing {
+              image {
+                ${maxHeight?.let { "max-height = $it" } ?: ""}
+                ${maxWidth?.let { "max-width = $it" } ?: ""}
+              }
             }
-        ]
+          }
+        }
         """.trimIndent(),
     ) {
         val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -187,17 +184,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
         expectedType: String,
     ) = testInMemory(
         """
-        paths = [
-            {
-                path = "/**"
-                preprocessing {
-                    enabled = true
-                    image {
-                        format = $imageFormat
-                    }
-                }
+        paths {
+          "/**" {
+            preprocessing {
+              enabled = true
+              image {
+                format = $imageFormat
+              }
             }
-        ]
+          }
+        }
         """.trimIndent(),
     ) {
         val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -228,27 +224,25 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `image preprocessing is available per route`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            format = jpg
-                            max-height = 55
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    format = jpg
+                    max-height = 55
+                  }
                 }
-                {
-                    path = "/Users/*/Profile"
-                    preprocessing {
-                        image {
-                            format = webp
-                            max-height = 50
-                        }
-                    }
+              }
+              "/Users/*/Profile" {
+                preprocessing {
+                  image {
+                    format = webp
+                    max-height = 50
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -282,18 +276,17 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `image is not preprocessed if preprocessing is disabled`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = false
-                        image {
-                            format = jpg
-                            max-height = 55
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = false
+                  image {
+                    format = jpg
+                    max-height = 55
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -322,27 +315,25 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `image is not preprocessed if preprocessing is disabled in parent path and not defined in current`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = false
-                        image {
-                            format = jpg
-                            max-height = 55
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = false
+                  image {
+                    format = jpg
+                    max-height = 55
+                  }
                 }
-                {
-                    path = "/Users/*/Profile"
-                    preprocessing {
-                        image {
-                            format = webp
-                            max-height = 50
-                        }
-                    }
+              }
+              "/Users/*/Profile" {
+                preprocessing {
+                  image {
+                    format = webp
+                    max-height = 50
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -371,17 +362,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `exif thumbnail data is removed if image is preprocessed`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            max-height = 50
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    max-height = 50
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
@@ -399,17 +389,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `metadata is removed if configured`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            strip = [ exif, xmp, iptc ]
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    strip = [ exif, xmp, iptc ]
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/metadata/exif-xmp-iptc.jpg")!!.readBytes()
@@ -430,17 +419,16 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `color space can be transformed if configured`() =
         testInMemory(
             """
-            paths = [
-            {
-                path = "/**"
+            paths {
+              "/**" {
                 preprocessing {
-                    enabled = true
-                    image {
-                        cs = srgb
-                    }
+                  enabled = true
+                  image {
+                    cs = srgb
+                  }
                 }
+              }
             }
-            ]
             """.trimIndent(),
         ) {
         }
@@ -452,18 +440,17 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
     fun `can preprocess large image`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            max-width = 3000
-                            format = png
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    max-width = 3000
+                    format = png
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/large/joshua-tree.jpeg")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantAttributesTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantAttributesTest.kt
@@ -32,19 +32,18 @@ class VariantAttributesTest : BaseFunctionalTest() {
     fun `height and width are populated when image is stored and preprocessed`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    preprocessing {
-                        enabled = true
-                        image {
-                            w = 200
-                            h = 200
-                            fit = stretch
-                        }
-                    }
+            paths {
+              "/**" {
+                preprocessing {
+                  enabled = true
+                  image {
+                    w = 200
+                    h = 200
+                    fit = stretch
+                  }
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantGenerationFailedTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantGenerationFailedTest.kt
@@ -34,15 +34,14 @@ class VariantGenerationFailedTest : BaseFunctionalTest() {
         testInMemory(
             configuration =
                 """
-                paths = [
-                  {
-                    path = "/**"
+                paths {
+                  "/**" {
                     preprocessing {
                       enabled = true
                       w = 100
                     }
                   }
-                ]
+                }
                 """.trimIndent(),
             modules =
                 listOf(

--- a/service/src/functionalTest/kotlin/io/konifer/image/ImagePreviewTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/image/ImagePreviewTest.kt
@@ -25,14 +25,13 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `blurhash is generated and returned when storing an asset`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/lqip/lqip-test-1.png")!!.readBytes()
@@ -45,14 +44,13 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `thumbhash is generated and returned when storing an asset`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/lqip/lqip-test-1.png")!!.readBytes()
@@ -65,14 +63,13 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `blurhash and thumbhash are generated and returned when storing an asset`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/lqip/lqip-test-1.png")!!.readBytes()
@@ -85,14 +82,13 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `no lqip is generated when storing an asset if none specified`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/lqip/lqip-test-1.png")!!.readBytes()
@@ -105,12 +101,11 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `no lqip is generated when storing an asset if not enabled`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image { }
-                }
-            ]
+            paths {
+              "/**" {
+                image { }
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/lqip/lqip-test-1.png")!!.readBytes()
@@ -123,14 +118,13 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `requesting a variant gives back the same LQIPs if only resizing is done`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/lqip/lqip-test-1.png")!!.readBytes()
@@ -162,14 +156,13 @@ class ImagePreviewTest : BaseFunctionalTest() {
     fun `lqips are not regenerated when requesting variant with blur`() =
         testInMemory(
             """
-            paths = [
-                {
-                    path = "/**"
-                    image {
-                        lqip = [ "thumbhash", "blurhash" ]
-                    }
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
                 }
-            ]
+              }
+            }
             """.trimIndent(),
         ) {
             val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()

--- a/service/src/main/kotlin/io/konifer/domain/variant/preprocessing/PreProcessingProperties.kt
+++ b/service/src/main/kotlin/io/konifer/domain/variant/preprocessing/PreProcessingProperties.kt
@@ -1,10 +1,15 @@
 package io.konifer.domain.variant.preprocessing
 
+import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.ImagePropertyKeys.PreProcessingPropertyKeys.ENABLED
+import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.ImagePropertyKeys.PreProcessingPropertyKeys.IMAGE
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class PreProcessingProperties(
+    @SerialName(ENABLED)
     val enabled: Boolean = false,
+    @SerialName(IMAGE)
     val image: ImagePreProcessingProperties = ImagePreProcessingProperties.default,
 ) {
     companion object Factory {

--- a/service/src/main/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepository.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepository.kt
@@ -1,13 +1,11 @@
 package io.konifer.infrastructure.path
 
 import com.typesafe.config.Config
-import com.typesafe.config.ConfigException
 import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigObject
 import io.konifer.domain.path.PathConfiguration
 import io.konifer.domain.ports.PathConfigurationRepository
 import io.konifer.infrastructure.property.ConfigurationPropertyKeys
-import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.PATH
-import io.ktor.server.config.tryGetString
 import io.ktor.util.logging.KtorSimpleLogger
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.hocon.Hocon
@@ -49,39 +47,41 @@ class TriePathConfigurationRepository(
 
     @OptIn(ExperimentalSerializationApi::class)
     private fun constructPathConfigurationTrie(config: Config) {
-        val pathConfigs =
-            if (config.hasPath(ConfigurationPropertyKeys.PATH_CONFIGURATION)) {
-                config.getConfigList(ConfigurationPropertyKeys.PATH_CONFIGURATION)
-            } else {
-                emptyList()
-            }
+        if (!config.hasPath(ConfigurationPropertyKeys.PATH_CONFIGURATION)) {
+            logger.info("No explicit paths configuration found, using defaults.")
+            return
+        }
 
-        val rootHoconConfig =
-            pathConfigs.firstOrNull {
-                it.tryGetString(PATH)?.trim() == DEFAULT_PATH
-            }
+        val pathsConfig = config.getConfig(ConfigurationPropertyKeys.PATH_CONFIGURATION)
+        val pathsMap = pathsConfig.root()
 
-        if (rootHoconConfig != null) {
-            val cleanRootConfig = rootHoconConfig.withoutPath(PATH)
-            root.rawConfig = cleanRootConfig
-            root.parsedConfig = Hocon.decodeFromConfig<PathConfiguration>(cleanRootConfig)
+        // Handle the root/default path first so everything else can inherit from it
+        val rootValue = pathsMap[DEFAULT_PATH]
+        if (rootValue != null) {
+            val rootNodeConfig =
+                (rootValue as? ConfigObject)?.toConfig()
+                    ?: throw IllegalArgumentException("Configuration for $DEFAULT_PATH must be an object")
+
+            root.rawConfig = rootNodeConfig
+            root.parsedConfig = Hocon.decodeFromConfig<PathConfiguration>(rootNodeConfig)
             root.hasExplicitConfiguration = true
             logger.info("Applied base configuration to root node from $DEFAULT_PATH")
         }
 
-        pathConfigs.forEach { pathConfig ->
-            val pathString =
-                try {
-                    pathConfig.getString(PATH).trim()
-                } catch (_: ConfigException.Missing) {
-                    throw IllegalArgumentException("Path configuration must be supplied")
-                }
+        // Iterate over the remaining map entries
+        pathsMap.forEach { (pathKey, configValue) ->
+            if (pathKey.isBlank()) {
+                throw IllegalArgumentException("Path key cannot be blank")
+            }
+            if (pathKey != DEFAULT_PATH) {
+                val nodeConfig =
+                    (configValue as? ConfigObject)?.toConfig()
+                        ?: throw IllegalArgumentException("Configuration for path '$pathKey' must be an object")
 
-            if (pathString != DEFAULT_PATH) {
-                logger.info("Parsing config for specific path: $pathString")
+                logger.info("Parsing config for specific path: $pathKey")
                 insertPath(
-                    path = pathString,
-                    nodeConfig = pathConfig,
+                    path = pathKey,
+                    nodeConfig = nodeConfig,
                 )
             }
         }
@@ -106,13 +106,11 @@ class TriePathConfigurationRepository(
             current = current.getOrCreateChild(segment, current.rawConfig, current.parsedConfig)
         }
 
+        // Merge the explicit configuration with the inherited configuration
         val mergedRawConfig = nodeConfig.withFallback(current.rawConfig)
 
-        // Remove the "path" key so the Serializer doesn't complain about an unknown key
-        val cleanConfigForParsing = mergedRawConfig.withoutPath(PATH)
-
         current.rawConfig = mergedRawConfig
-        current.parsedConfig = Hocon.decodeFromConfig<PathConfiguration>(cleanConfigForParsing)
+        current.parsedConfig = Hocon.decodeFromConfig<PathConfiguration>(mergedRawConfig)
         current.hasExplicitConfiguration = true
     }
 

--- a/service/src/main/kotlin/io/konifer/infrastructure/property/ConfigurationPropertyKeys.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/property/ConfigurationPropertyKeys.kt
@@ -74,7 +74,6 @@ object ConfigurationPropertyKeys {
 
     object PathPropertyKeys {
         const val IMAGE = "image"
-        const val PATH = "path"
         const val ALLOWED_CONTENT_TYPES = "allowed-content-types"
         const val EAGER_VARIANTS = "eager-variants"
         const val OBJECT_STORE = "object-store"

--- a/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
@@ -12,21 +12,19 @@ class TriePathConfigurationRepositoryTest {
     fun `fetch returns a path configuration when the path matches exactly`() {
         val config =
             """
-            paths = [
-              {
-                path = "/users/123/profile"
+            paths {
+              "/users/123/profile" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
-              },
-              {
-                path = "/users/456/profile"
+              }
+              "/users/456/profile" {
                 allowed-content-types = [
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -40,21 +38,19 @@ class TriePathConfigurationRepositoryTest {
     fun `fetch returns a path configuration when the path matches exactly but case does not`() {
         val config =
             """
-            paths = [
-              {
-                path = "/Users/123/Profile"
+            paths = {
+              "/Users/123/Profile" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
-              },
-              {
-                path = "/users/456/profile"
+              }
+              "/users/456/profile" {
                 allowed-content-types = [
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -73,15 +69,14 @@ class TriePathConfigurationRepositoryTest {
     fun `fetch returns a path configuration when the path matcher has single wildcard`() {
         val config =
             """
-            paths = [
-              {
-                path = "/users/*/profile"
+            paths {
+              "/users/*/profile" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -95,15 +90,14 @@ class TriePathConfigurationRepositoryTest {
     fun `fetch returns a path configuration when the path matcher has double wildcard`() {
         val config =
             """
-            paths = [
-              {
-                path = "/users/**"
+            paths {
+              "/users/**" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -124,15 +118,14 @@ class TriePathConfigurationRepositoryTest {
     fun `fetch does not return a path configuration when the path matcher does not match`(path: String) {
         val config =
             """
-            paths = [
-              {
-                path = "$path"
+            paths {
+              "$path" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -154,15 +147,14 @@ class TriePathConfigurationRepositoryTest {
     fun `greedy wildcard matching works`(path: String) {
         val config =
             """
-            paths = [
-              {
-                path = "$path"
+            paths {
+              "$path" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -177,9 +169,8 @@ class TriePathConfigurationRepositoryTest {
     fun `path configuration is inherited if not supplied`() {
         val config =
             """
-            paths = [
-              {
-                path = "/users/*"
+            paths {
+              "/users/*" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
@@ -189,17 +180,16 @@ class TriePathConfigurationRepositoryTest {
                     max-height = 10
                   }
                 }
-              },
-              {
-                path = "/users/*/profile"
+              }
+              "/users/*/profile" {
                 allowed-content-types = [ ]
                 preprocessing = {
                   image {
                     max-width = 10
                   }
                 }
-              },
-            ]
+              }
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -215,19 +205,17 @@ class TriePathConfigurationRepositoryTest {
     fun `default path is used when none suffice`() {
         val config =
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
-              },
-              {
-                path = "/users/**"
+              }
+              "/users/**" {
                 allowed-content-types = [ ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -241,9 +229,8 @@ class TriePathConfigurationRepositoryTest {
     fun `default path configuration is inherited`() {
         val config =
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
@@ -253,17 +240,16 @@ class TriePathConfigurationRepositoryTest {
                     max-height = 10
                   }
                 }
-              },
-              {
-                path = "/users/*/profile"
+              }
+              "/users/*/profile" {
                 allowed-content-types = [ ]
                 preprocessing = {
                   image {
                     max-width = 10
                   }
                 }
-              },
-            ]
+              }
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -279,15 +265,14 @@ class TriePathConfigurationRepositoryTest {
     fun `path is stripped of blank and empty path segments`() {
         val config =
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -301,32 +286,31 @@ class TriePathConfigurationRepositoryTest {
     fun `path must be supplied`() {
         val config =
             """
-            paths = [
-              {
+            paths {
+              "" {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
                 ]
               }
-            ]
+            }
             """.trimIndent()
         shouldThrow<IllegalArgumentException> {
             TriePathConfigurationRepository(
                 ConfigFactory.parseString(config),
             )
-        }.message shouldBe "Path configuration must be supplied"
+        }.message shouldBe "Path key cannot be blank"
     }
 
     @Test
     fun `eager variants are parsed`() {
         val config =
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 eager-variants = [small, large]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -340,16 +324,14 @@ class TriePathConfigurationRepositoryTest {
     fun `eager variants override parent paths`() {
         val config =
             """
-            paths = [
-              {
-                path = "/**"
+            paths {
+              "/**" {
                 eager-variants = [small, large]
-              },
-              {
-                path = "/profile/*"
+              }
+              "/profile/*" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -364,12 +346,11 @@ class TriePathConfigurationRepositoryTest {
     fun `configuration under wildcard is applied at the root of the path`(path: String) {
         val config =
             """
-            paths = [
-              {
-                path = "$path*"
+            paths {
+              "$path*" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -384,12 +365,11 @@ class TriePathConfigurationRepositoryTest {
     fun `configuration under greedy wildcard is applied at the root of the path`(path: String) {
         val config =
             """
-            paths = [
-              {
-                path = "$path**"
+            paths {
+              "$path**" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -404,16 +384,14 @@ class TriePathConfigurationRepositoryTest {
     fun `wildcard wins over greedy wildcard specified on same path`(path: String) {
         val config =
             """
-            paths = [
-              {
-                path = "/profile/*"
+            paths {
+              "/profile/*" {
                 eager-variants = [medium]
               }
-              {
-                path = "/profile/**"
+              "/profile/**" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
         val pathConfigurationRepository =
             TriePathConfigurationRepository(
@@ -427,16 +405,14 @@ class TriePathConfigurationRepositoryTest {
     fun `exact path wins over wildcard on same path`() {
         val config =
             """
-            paths = [
-              {
-                path = "/profile/123"
+            paths {
+              "/profile/123" {
                 eager-variants = [small]
-              },
-              {
-                path = "/profile/*"
+              }
+              "/profile/*" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
 
         val repository =
@@ -451,16 +427,14 @@ class TriePathConfigurationRepositoryTest {
     fun `exact path wins over greedy wildcard on same path`() {
         val config =
             """
-            paths = [
-              {
-                path = "/profile/123"
+            paths {
+              "/profile/123" {
                 eager-variants = [small]
-              },
-              {
-                path = "/profile/**"
+              }
+              "/profile/**" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
 
         val repository =
@@ -475,16 +449,14 @@ class TriePathConfigurationRepositoryTest {
     fun `explicit parent path wins over wildcard child when fetching parent path`() {
         val config =
             """
-            paths = [
-              {
-                path = "/profile"
+            paths {
+              "/profile" {
                 eager-variants = [small]
-              },
-              {
-                path = "/profile/*"
+              }
+              "/profile/*" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
 
         val repository =
@@ -499,12 +471,11 @@ class TriePathConfigurationRepositoryTest {
     fun `greedy wildcard can consume zero segments before matching following segment`() {
         val config =
             """
-            paths = [
-              {
-                path = "/users/**/profile"
+            paths {
+              "/users/**/profile" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
 
         val repository =
@@ -519,16 +490,14 @@ class TriePathConfigurationRepositoryTest {
     fun `deeper greedy wildcard match wins over shallower greedy wildcard match`() {
         val config =
             """
-            paths = [
-              {
-                path = "/users/**"
+            paths {
+              "/users/**" {
                 eager-variants = [small]
-              },
-              {
-                path = "/users/**/profile"
+              }
+              "/users/**/profile" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
 
         val repository =
@@ -543,12 +512,11 @@ class TriePathConfigurationRepositoryTest {
     fun `configured path is stripped of blank and empty path segments`() {
         val config =
             """
-            paths = [
-              {
-                path = "//profile//*/"
+            paths {
+              "//profile//*/" {
                 eager-variants = [large]
               }
-            ]
+            }
             """.trimIndent()
 
         val repository =


### PR DESCRIPTION
This is always what I wanted but it seemed to be a library limitation (and it still kind of is unless I reflectively pull out the raw `Config` from Ktor's abstraction).