### PR TITLE
Refactor eager-variants and preprocessing under a transform namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,19 +149,27 @@ Profiles can also be used for eager variants, where Konifer starts background ge
 Different parts of your image hierarchy can behave differently. Path configuration lets you define rules once in `konifer.conf` and apply them with wildcard matching and inheritance.
 
 ```hocon
+variant-profiles {
+  thumbnail {
+    w = 256
+    fit = fill
+  }
+}
 paths {
   "/public/avatars/**" {
-    eager-variants = [thumbnail]
+    transform {
+      eager-variants = [thumbnail]
+      preprocessing {
+        enabled = true
+        image {
+          max-width = 1024
+          max-height = 1024
+          fit = fit
+        }
+      }
+    }
     image {
       lqip = [blurhash, thumbhash]
-    }
-    preprocessing {
-      enabled = true
-      image {
-        max-width = 1024
-        max-height = 1024
-        fit = fit
-      }
     }
     cache-control {
       enabled = true

--- a/performance/runtime/konifer.conf
+++ b/performance/runtime/konifer.conf
@@ -46,20 +46,24 @@ variant-profiles {
 
 paths {
   "/test-upload-eager-variants" {
-    eager-variants = [
-      thumbnail-200,
-      thumbnail-400,
-      thumbnail-600,
-      sepia-original
-    ]
+    transform {
+      eager-variants = [
+        thumbnail-200,
+        thumbnail-400,
+        thumbnail-600,
+        sepia-original
+      ]
+    }
   }
   "/test-upload-preprocessing" {
-    preprocessing {
-      enabled = true
-      image {
-        r = auto
-        format = jxl
-        pad = 10
+    transform {
+      preprocessing {
+        enabled = true
+        image {
+          r = auto
+          format = jxl
+          pad = 10
+        }
       }
     }
   }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/StoreAssetTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/StoreAssetTest.kt
@@ -186,10 +186,12 @@ class StoreAssetTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    format = ${format.format}
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      format = ${format.format}
+                    }
                   }
                 }
               }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/EagerVariantTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/EagerVariantTest.kt
@@ -41,7 +41,9 @@ class EagerVariantTest : BaseFunctionalTest() {
             }
             paths {
               "/users/**" {
-                eager-variants = [small, medium]
+                transform {
+                  eager-variants = [small, medium]
+                }
               }
             }
             """.trimIndent(),
@@ -106,7 +108,9 @@ class EagerVariantTest : BaseFunctionalTest() {
                 }
               }
               "/users/**" {
-                eager-variants = [small, medium]
+                transform {
+                  eager-variants = [small, medium]
+                }
                 object-store {
                   bucket = correct-bucket
                 }
@@ -152,11 +156,13 @@ class EagerVariantTest : BaseFunctionalTest() {
             }
             paths {
               "/users/**" {
-                eager-variants = [small]
-                preprocessing {
-                  enabled = true
-                  image {
-                    r = 180
+                transform {
+                  eager-variants = [small]
+                  preprocessing {
+                    enabled = true
+                    image {
+                      r = 180
+                    }
                   }
                 }
               }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImagePreProcessingTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImagePreProcessingTest.kt
@@ -49,10 +49,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    max-width = 100
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      max-width = 100
+                    }
                   }
                 }
               }
@@ -92,10 +94,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    max-height = 50
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      max-height = 50
+                    }
                   }
                 }
               }
@@ -140,10 +144,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
         """
         paths {
           "/**" {
-            preprocessing {
-              image {
-                ${maxHeight?.let { "max-height = $it" } ?: ""}
-                ${maxWidth?.let { "max-width = $it" } ?: ""}
+            transform {
+              preprocessing {
+                image {
+                  ${maxHeight?.let { "max-height = $it" } ?: ""}
+                  ${maxWidth?.let { "max-width = $it" } ?: ""}
+                }
               }
             }
           }
@@ -186,10 +192,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
         """
         paths {
           "/**" {
-            preprocessing {
-              enabled = true
-              image {
-                format = $imageFormat
+            transform {
+              preprocessing {
+                enabled = true
+                image {
+                  format = $imageFormat
+                }
               }
             }
           }
@@ -226,19 +234,23 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    format = jpg
-                    max-height = 55
-                  }
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      format = jpg
+                      max-height = 55
+                    }
+                  }  
                 }
               }
               "/Users/*/Profile" {
-                preprocessing {
-                  image {
-                    format = webp
-                    max-height = 50
+                transform {
+                  preprocessing {
+                    image {
+                      format = webp
+                      max-height = 50
+                    }
                   }
                 }
               }
@@ -278,11 +290,13 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = false
-                  image {
-                    format = jpg
-                    max-height = 55
+                transform {
+                  preprocessing {
+                    enabled = false
+                    image {
+                      format = jpg
+                      max-height = 55
+                    }
                   }
                 }
               }
@@ -317,19 +331,23 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = false
-                  image {
-                    format = jpg
-                    max-height = 55
+                transform {
+                  preprocessing {
+                    enabled = false
+                    image {
+                      format = jpg
+                      max-height = 55
+                    }
                   }
                 }
               }
               "/Users/*/Profile" {
-                preprocessing {
-                  image {
-                    format = webp
-                    max-height = 50
+                transform {
+                  preprocessing {
+                    image {
+                      format = webp
+                      max-height = 50
+                    }
                   }
                 }
               }
@@ -364,10 +382,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    max-height = 50
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      max-height = 50
+                    }
                   }
                 }
               }
@@ -391,10 +411,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    strip = [ exif, xmp, iptc ]
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      strip = [ exif, xmp, iptc ]
+                    }
                   }
                 }
               }
@@ -421,10 +443,12 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    cs = srgb
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      cs = srgb
+                    }
                   }
                 }
               }
@@ -442,11 +466,13 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    max-width = 3000
-                    format = png
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      max-width = 3000
+                      format = png
+                    }
                   }
                 }
               }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantAttributesTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantAttributesTest.kt
@@ -34,12 +34,14 @@ class VariantAttributesTest : BaseFunctionalTest() {
             """
             paths {
               "/**" {
-                preprocessing {
-                  enabled = true
-                  image {
-                    w = 200
-                    h = 200
-                    fit = stretch
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      w = 200
+                      h = 200
+                      fit = stretch
+                    }
                   }
                 }
               }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantGenerationFailedTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/VariantGenerationFailedTest.kt
@@ -36,9 +36,11 @@ class VariantGenerationFailedTest : BaseFunctionalTest() {
                 """
                 paths {
                   "/**" {
-                    preprocessing {
-                      enabled = true
-                      w = 100
+                    transform {
+                      preprocessing {
+                        enabled = true
+                        w = 100
+                      }
                     }
                   }
                 }

--- a/service/src/main/kotlin/io/konifer/application/listener/AssetEventListener.kt
+++ b/service/src/main/kotlin/io/konifer/application/listener/AssetEventListener.kt
@@ -43,7 +43,7 @@ class AssetEventListener(
     suspend fun handle(event: AssetReadyEvent) {
         try {
             val eagerVariantTransformations =
-                event.pathConfiguration.eagerVariants
+                event.pathConfiguration.transform.eagerVariants
                     .map { profileName ->
                         variantProfileRepository.fetch(profileName)
                     }.takeIf { it.isNotEmpty() }

--- a/service/src/main/kotlin/io/konifer/application/service/VariantProcessorPipeline.kt
+++ b/service/src/main/kotlin/io/konifer/application/service/VariantProcessorPipeline.kt
@@ -41,7 +41,9 @@ class VariantProcessorPipeline(
         format: ImageFormat,
     ): ProcessingPipeline {
         container.toTemporaryFile(format.extension)
-        val hasEagerVariants = context.pathConfiguration.eagerVariants.isNotEmpty()
+        val hasEagerVariants =
+            context.pathConfiguration.transform.eagerVariants
+                .isNotEmpty()
 
         return if (context.requiresPreProcessing()) {
             buildPreProcessingPipeline(
@@ -178,12 +180,12 @@ class VariantProcessorPipeline(
     ): Transformation =
         withContext(Dispatchers.IO) {
             val requestedTransformation =
-                context.pathConfiguration.preProcessing.image.requestedImageTransformation
+                context.pathConfiguration.transform.preProcessing.image.requestedImageTransformation
             var transformation: Transformation? = null
 
             Vips.run { arena ->
                 val destinationFormat =
-                    context.pathConfiguration.preProcessing.image.format
+                    context.pathConfiguration.transform.preProcessing.image.format
                         ?: sourceFormat
                 // Even if this image is paged, just need to load one frame to get height/width
                 // So don't specify "n" as an option

--- a/service/src/main/kotlin/io/konifer/domain/context/StoreRequestContext.kt
+++ b/service/src/main/kotlin/io/konifer/domain/context/StoreRequestContext.kt
@@ -10,5 +10,6 @@ data class StoreRequestContext(
      * Does the asset require preprocessing? This is false only when processing is disabled within
      * path configuration and there are no lqips to generate.
      */
-    fun requiresPreProcessing(): Boolean = pathConfiguration.preProcessing.enabled || pathConfiguration.image.previews.isNotEmpty()
+    fun requiresPreProcessing(): Boolean =
+        pathConfiguration.transform.preProcessing.enabled || pathConfiguration.image.previews.isNotEmpty()
 }

--- a/service/src/main/kotlin/io/konifer/domain/path/PathConfiguration.kt
+++ b/service/src/main/kotlin/io/konifer/domain/path/PathConfiguration.kt
@@ -2,7 +2,7 @@ package io.konifer.domain.path
 
 import io.konifer.common.image.ImageFormat
 import io.konifer.domain.image.ImageProperties
-import io.konifer.domain.variant.preprocessing.PreProcessingProperties
+import io.konifer.domain.variant.TransformProperties
 import io.konifer.infrastructure.property.ConfigurationPropertyKeys
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -11,12 +11,10 @@ import kotlinx.serialization.Serializable
 data class PathConfiguration(
     @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.ALLOWED_CONTENT_TYPES)
     val allowedContentTypes: List<String>? = null,
-    @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.PREPROCESSING)
-    val preProcessing: PreProcessingProperties = PreProcessingProperties.default,
+    @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.TRANSFORM)
+    val transform: TransformProperties = TransformProperties.default,
     @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.IMAGE)
     val image: ImageProperties = ImageProperties.default,
-    @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.EAGER_VARIANTS)
-    val eagerVariants: List<String> = emptyList(),
     @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.OBJECT_STORE)
     val objectStore: ObjectStoreProperties = ObjectStoreProperties.default,
     @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.RETURN_FORMAT)
@@ -32,12 +30,11 @@ data class PathConfiguration(
         val default =
             PathConfiguration(
                 allowedContentTypes = null,
-                preProcessing = PreProcessingProperties.default,
                 image = ImageProperties.default,
-                eagerVariants = emptyList(),
                 objectStore = ObjectStoreProperties.default,
                 returnFormat = ReturnFormatProperties.default,
                 cacheControl = CacheControlProperties.default,
+                transform = TransformProperties.default,
             )
     }
 

--- a/service/src/main/kotlin/io/konifer/domain/variant/TransformProperties.kt
+++ b/service/src/main/kotlin/io/konifer/domain/variant/TransformProperties.kt
@@ -1,0 +1,18 @@
+package io.konifer.domain.variant
+
+import io.konifer.domain.variant.preprocessing.PreProcessingProperties
+import io.konifer.infrastructure.property.ConfigurationPropertyKeys
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TransformProperties(
+    @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.TransformPropertyKeys.PREPROCESSING)
+    val preProcessing: PreProcessingProperties = PreProcessingProperties.default,
+    @SerialName(ConfigurationPropertyKeys.PathPropertyKeys.TransformPropertyKeys.EAGER_VARIANTS)
+    val eagerVariants: List<String> = emptyList(),
+) {
+    companion object Factory {
+        val default = TransformProperties()
+    }
+}

--- a/service/src/main/kotlin/io/konifer/domain/variant/preprocessing/ImagePreProcessingProperties.kt
+++ b/service/src/main/kotlin/io/konifer/domain/variant/preprocessing/ImagePreProcessingProperties.kt
@@ -9,7 +9,7 @@ import io.konifer.common.image.ManipulationParameters
 import io.konifer.common.image.Rotate
 import io.konifer.common.image.TransformableColorSpace
 import io.konifer.domain.context.RequestedTransformation
-import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.ImagePropertyKeys.PreProcessingPropertyKeys
+import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.TransformPropertyKeys.PreProcessingPropertyKeys
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/service/src/main/kotlin/io/konifer/domain/variant/preprocessing/PreProcessingProperties.kt
+++ b/service/src/main/kotlin/io/konifer/domain/variant/preprocessing/PreProcessingProperties.kt
@@ -1,7 +1,7 @@
 package io.konifer.domain.variant.preprocessing
 
-import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.ImagePropertyKeys.PreProcessingPropertyKeys.ENABLED
-import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.ImagePropertyKeys.PreProcessingPropertyKeys.IMAGE
+import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.TransformPropertyKeys.PreProcessingPropertyKeys.ENABLED
+import io.konifer.infrastructure.property.ConfigurationPropertyKeys.PathPropertyKeys.TransformPropertyKeys.PreProcessingPropertyKeys.IMAGE
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/service/src/main/kotlin/io/konifer/infrastructure/property/ConfigurationPropertyKeys.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/property/ConfigurationPropertyKeys.kt
@@ -75,14 +75,18 @@ object ConfigurationPropertyKeys {
     object PathPropertyKeys {
         const val IMAGE = "image"
         const val ALLOWED_CONTENT_TYPES = "allowed-content-types"
-        const val EAGER_VARIANTS = "eager-variants"
         const val OBJECT_STORE = "object-store"
         const val RETURN_FORMAT = "return-format"
-        const val PREPROCESSING = "preprocessing"
+        const val TRANSFORM = "transform"
         const val CACHE_CONTROL = "cache-control"
 
         object ImagePropertyKeys {
             const val LQIP = "lqip"
+        }
+
+        object TransformPropertyKeys {
+            const val PREPROCESSING = "preprocessing"
+            const val EAGER_VARIANTS = "eager-variants"
 
             object PreProcessingPropertyKeys {
                 const val ENABLED = "enabled"
@@ -93,10 +97,6 @@ object ConfigurationPropertyKeys {
                     const val MAX_WIDTH = "max-width"
                 }
             }
-        }
-
-        object VariantProfilePropertyKeys {
-            const val NAME = "name"
         }
 
         object ObjectStorePropertyKeys {

--- a/service/src/test/kotlin/io/konifer/domain/context/RequestContextFactoryTest.kt
+++ b/service/src/test/kotlin/io/konifer/domain/context/RequestContextFactoryTest.kt
@@ -18,7 +18,6 @@ import io.konifer.domain.path.PathConfiguration
 import io.konifer.domain.path.ReturnFormatProperties
 import io.konifer.domain.transformation.TransformationNormalizer
 import io.konifer.domain.variant.Transformation
-import io.konifer.domain.variant.preprocessing.PreProcessingProperties
 import io.konifer.infrastructure.path.TriePathConfigurationRepository
 import io.konifer.infrastructure.variant.profile.ConfigurationVariantProfileRepository
 import io.kotest.assertions.throwables.shouldNotThrowAny
@@ -1195,9 +1194,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                 PathConfiguration(
                     allowedContentTypes = listOf("image/png"),
                     image = ImageProperties.default,
-                    eagerVariants = listOf(),
                     objectStore = ObjectStoreProperties.default,
-                    preProcessing = PreProcessingProperties.default,
                     cacheControl = CacheControlProperties.default,
                     returnFormat = ReturnFormatProperties.default,
                 )
@@ -1226,9 +1223,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                 PathConfiguration(
                     allowedContentTypes = listOf("image/jpeg"),
                     image = ImageProperties.default,
-                    eagerVariants = listOf(),
                     objectStore = ObjectStoreProperties.default,
-                    preProcessing = PreProcessingProperties.default,
                     cacheControl = CacheControlProperties.default,
                     returnFormat = ReturnFormatProperties.default,
                 )

--- a/service/src/test/kotlin/io/konifer/infrastructure/path/PathConfigurationTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/path/PathConfigurationTest.kt
@@ -5,7 +5,6 @@ import io.konifer.domain.path.CacheControlProperties
 import io.konifer.domain.path.ObjectStoreProperties
 import io.konifer.domain.path.PathConfiguration
 import io.konifer.domain.path.ReturnFormatProperties
-import io.konifer.domain.variant.preprocessing.PreProcessingProperties
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
@@ -21,9 +20,7 @@ class PathConfigurationTest {
                         ImageProperties(
                             previews = setOf(),
                         ),
-                    eagerVariants = emptyList(),
                     objectStore = ObjectStoreProperties.default,
-                    preProcessing = PreProcessingProperties.default,
                     cacheControl = CacheControlProperties.default,
                     returnFormat = ReturnFormatProperties.default,
                 )

--- a/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
@@ -175,18 +175,22 @@ class TriePathConfigurationRepositoryTest {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
-                ],
-                preprocessing = {
-                  image {
-                    max-height = 10
+                ]
+                transform {
+                  preprocessing = {
+                    image {
+                      max-height = 10
+                    }
                   }
                 }
               }
               "/users/*/profile" {
                 allowed-content-types = [ ]
-                preprocessing = {
-                  image {
-                    max-width = 10
+                transform {
+                  preprocessing = {
+                    image {
+                      max-width = 10
+                    }
                   }
                 }
               }
@@ -198,8 +202,8 @@ class TriePathConfigurationRepositoryTest {
             )
         val pathConfiguration = pathConfigurationRepository.fetch("/users/123/profile")
         pathConfiguration.allowedContentTypes shouldBe listOf()
-        pathConfiguration.preProcessing.image.maxWidth shouldBe 10
-        pathConfiguration.preProcessing.image.maxHeight shouldBe 10
+        pathConfiguration.transform.preProcessing.image.maxWidth shouldBe 10
+        pathConfiguration.transform.preProcessing.image.maxHeight shouldBe 10
     }
 
     @Test
@@ -235,18 +239,22 @@ class TriePathConfigurationRepositoryTest {
                 allowed-content-types = [
                   "image/png",
                   "image/jpeg"
-                ],
-                preprocessing = {
-                  image {
-                    max-height = 10
+                ]
+                transform {
+                  preprocessing = {
+                    image {
+                      max-height = 10
+                    }
                   }
                 }
               }
               "/users/*/profile" {
                 allowed-content-types = [ ]
-                preprocessing = {
-                  image {
-                    max-width = 10
+                transform {
+                  preprocessing = {
+                    image {
+                      max-width = 10
+                    }
                   }
                 }
               }
@@ -258,8 +266,8 @@ class TriePathConfigurationRepositoryTest {
             )
         val pathConfiguration = pathConfigurationRepository.fetch("/users/123/profile")
         pathConfiguration.allowedContentTypes shouldBe listOf()
-        pathConfiguration.preProcessing.image.maxWidth shouldBe 10
-        pathConfiguration.preProcessing.image.maxHeight shouldBe 10
+        pathConfiguration.transform.preProcessing.image.maxWidth shouldBe 10
+        pathConfiguration.transform.preProcessing.image.maxHeight shouldBe 10
     }
 
     @Test
@@ -309,7 +317,9 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/**" {
-                eager-variants = [small, large]
+                transform {
+                  eager-variants = [small, large]
+                }
               }
             }
             """.trimIndent()
@@ -318,7 +328,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
         val pathConfiguration = pathConfigurationRepository.fetch("/profile")
-        pathConfiguration.eagerVariants shouldBe listOf("small", "large")
+        pathConfiguration.transform.eagerVariants shouldBe listOf("small", "large")
     }
 
     @Test
@@ -327,10 +337,14 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/**" {
-                eager-variants = [small, large]
+                transform {
+                  eager-variants = [small, large]
+                }
               }
               "/profile/*" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -339,7 +353,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
         val pathConfiguration = pathConfigurationRepository.fetch("/profile/123")
-        pathConfiguration.eagerVariants shouldBe listOf("large")
+        pathConfiguration.transform.eagerVariants shouldBe listOf("large")
     }
 
     @ParameterizedTest
@@ -349,7 +363,9 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "$path*" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -358,7 +374,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
         val pathConfiguration = pathConfigurationRepository.fetch(path)
-        pathConfiguration.eagerVariants shouldBe listOf("large")
+        pathConfiguration.transform.eagerVariants shouldBe listOf("large")
     }
 
     @ParameterizedTest
@@ -368,7 +384,9 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "$path**" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -377,7 +395,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
         val pathConfiguration = pathConfigurationRepository.fetch(path)
-        pathConfiguration.eagerVariants shouldBe listOf("large")
+        pathConfiguration.transform.eagerVariants shouldBe listOf("large")
     }
 
     @ParameterizedTest
@@ -387,10 +405,14 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/profile/*" {
-                eager-variants = [medium]
+                transform {
+                  eager-variants = [medium]
+                }
               }
               "/profile/**" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -399,7 +421,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
         val pathConfiguration = pathConfigurationRepository.fetch(path)
-        pathConfiguration.eagerVariants shouldBe listOf("medium")
+        pathConfiguration.transform.eagerVariants shouldBe listOf("medium")
     }
 
     @Test
@@ -408,10 +430,14 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/profile/123" {
-                eager-variants = [small]
+                transform {
+                  eager-variants = [small]
+                }
               }
               "/profile/*" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -421,7 +447,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
 
-        repository.fetch("/profile/123").eagerVariants shouldBe listOf("small")
+        repository.fetch("/profile/123").transform.eagerVariants shouldBe listOf("small")
     }
 
     @Test
@@ -430,10 +456,14 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/profile/123" {
-                eager-variants = [small]
+                transform {
+                  eager-variants = [small]
+                }
               }
               "/profile/**" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -443,7 +473,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
 
-        repository.fetch("/profile/123").eagerVariants shouldBe listOf("small")
+        repository.fetch("/profile/123").transform.eagerVariants shouldBe listOf("small")
     }
 
     @Test
@@ -452,10 +482,14 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/profile" {
-                eager-variants = [small]
+                transform {
+                  eager-variants = [small]
+                }
               }
               "/profile/*" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -465,7 +499,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
 
-        repository.fetch("/profile").eagerVariants shouldBe listOf("small")
+        repository.fetch("/profile").transform.eagerVariants shouldBe listOf("small")
     }
 
     @Test
@@ -474,7 +508,9 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/users/**/profile" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -484,7 +520,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
 
-        repository.fetch("/users/profile").eagerVariants shouldBe listOf("large")
+        repository.fetch("/users/profile").transform.eagerVariants shouldBe listOf("large")
     }
 
     @Test
@@ -493,10 +529,14 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "/users/**" {
-                eager-variants = [small]
+                transform {
+                  eager-variants = [small]
+                }
               }
               "/users/**/profile" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -506,7 +546,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
 
-        repository.fetch("/users/123/profile").eagerVariants shouldBe listOf("large")
+        repository.fetch("/users/123/profile").transform.eagerVariants shouldBe listOf("large")
     }
 
     @Test
@@ -515,7 +555,9 @@ class TriePathConfigurationRepositoryTest {
             """
             paths {
               "//profile//*/" {
-                eager-variants = [large]
+                transform {
+                  eager-variants = [large]
+                }
               }
             }
             """.trimIndent()
@@ -525,7 +567,7 @@ class TriePathConfigurationRepositoryTest {
                 ConfigFactory.parseString(config),
             )
 
-        repository.fetch("/profile/123").eagerVariants shouldBe listOf("large")
+        repository.fetch("/profile/123").transform.eagerVariants shouldBe listOf("large")
     }
 
     @ParameterizedTest


### PR DESCRIPTION
This will help with configuration that is coming around on-demand variants. Good to get this nailed down before the 1.0 release