### PR TITLE
Allow on-demand variants to be disabled in Path Configuration

### DIFF
--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/OnDemandVariantModeTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/OnDemandVariantModeTest.kt
@@ -118,9 +118,9 @@ class OnDemandVariantModeTest : BaseFunctionalTest() {
         }
 
     @ParameterizedTest
-    @ValueSource(strings = ["mode = enabled"])
+    @ValueSource(strings = ["mode = enabled", "mode = profile_only", "mode = disabled"])
     @EmptySource
-    fun `with enabled mode set then original variant can be specified`(config: String) =
+    fun `with any mode set then original variant can be specified`(config: String) =
         testInMemory(
             """
             paths {
@@ -148,5 +148,136 @@ class OnDemandVariantModeTest : BaseFunctionalTest() {
                 .fetchAssetContentBytes(
                     path = "users/123",
                 ).shouldBeSuccessful()
+        }
+
+    @Test
+    fun `on-demand variants cannot be generated when disabled`() =
+        testInMemory(
+            """
+            paths {
+              "/**" {
+                transform {
+                  on-demand-variant {
+                    mode = disabled
+                  }
+                }
+              }
+            }
+            """.trimIndent(),
+        ) {
+            val (image, attributes) = ImageFactory.testImage()
+
+            konifer
+                .storeAsset(
+                    path = "users/123",
+                    format = attributes.format,
+                    request = StoreAssetRequest(),
+                    bytes = image,
+                ).shouldBeSuccessful()
+
+            val errorResponse =
+                konifer.fetchAssetContentBytes(
+                    path = "users/123",
+                    requestedTransformation =
+                        requestedTransformation {
+                            width = 10
+                        },
+                ) shouldHaveHttpError 400
+
+            errorResponse.message shouldBe "Transformation not allowed"
+        }
+
+    @Test
+    fun `eager variant can be requested when on-demand variants are disabled`() =
+        testInMemory(
+            """
+            variant-profiles {
+              thumbnail {
+                w = 10
+              }
+            }
+            paths {
+              "/**" {
+                transform {
+                  on-demand-variant {
+                    mode = disabled
+                  }
+                  eager-variants = [thumbnail]
+                }
+              }
+            }
+            """.trimIndent(),
+        ) {
+            val (image, attributes) = ImageFactory.testImage()
+
+            konifer
+                .storeAsset(
+                    path = "users/123",
+                    format = attributes.format,
+                    request = StoreAssetRequest(),
+                    bytes = image,
+                ).shouldBeSuccessful()
+
+            konifer
+                .fetchAssetContentBytes(
+                    path = "users/123",
+                    requestedTransformation =
+                        requestedTransformation {
+                            profile = "thumbnail"
+                        },
+                ).shouldBeSuccessful()
+
+            // Transformation matches the profile definition
+            konifer
+                .fetchAssetContentBytes(
+                    path = "users/123",
+                    requestedTransformation =
+                        requestedTransformation {
+                            width = 10
+                        },
+                ).shouldBeSuccessful()
+        }
+
+    @Test
+    fun `profile must be listed as eager-variant to use when on-demand variants are disabled`() =
+        testInMemory(
+            """
+            variant-profiles {
+              thumbnail {
+                w = 10
+              }
+            }
+            paths {
+              "/**" {
+                transform {
+                  on-demand-variant {
+                    mode = disabled
+                  }
+                  eager-variants = []
+                }
+              }
+            }
+            """.trimIndent(),
+        ) {
+            val (image, attributes) = ImageFactory.testImage()
+
+            konifer
+                .storeAsset(
+                    path = "users/123",
+                    format = attributes.format,
+                    request = StoreAssetRequest(),
+                    bytes = image,
+                ).shouldBeSuccessful()
+
+            val errorResponse =
+                konifer.fetchAssetContentBytes(
+                    path = "users/123",
+                    requestedTransformation =
+                        requestedTransformation {
+                            profile = "thumbnail"
+                        },
+                ) shouldHaveHttpError 400
+
+            errorResponse.message shouldBe "Transformation not allowed"
         }
 }

--- a/service/src/main/kotlin/io/konifer/domain/context/RequestContextFactory.kt
+++ b/service/src/main/kotlin/io/konifer/domain/context/RequestContextFactory.kt
@@ -43,6 +43,7 @@ class RequestContextFactory(
     private val pathConfigurationRepository: PathConfigurationRepository,
     private val variantProfileRepository: VariantProfileRepository,
     private val transformationNormalizer: TransformationNormalizer,
+    private val requestContextValidator: RequestContextValidator,
 ) {
     companion object {
         const val PATH_NAMESPACE_SEPARATOR = "-"
@@ -72,7 +73,7 @@ class RequestContextFactory(
         )
     }
 
-    suspend fun fromGetRequest(
+    suspend fun fromFetchRequest(
         path: String,
         headers: Headers,
         queryParameters: Parameters,
@@ -90,7 +91,7 @@ class RequestContextFactory(
                 parameters = queryParameters,
             )
         val pathConfiguration = pathConfigurationRepository.fetch(segments.first())
-        RequestContextValidator.validateGetRequest(
+        requestContextValidator.validateFetchRequest(
             querySelectors = querySelectors,
             pathConfiguration = pathConfiguration,
             requestedTransformation = requestedTransformation,

--- a/service/src/main/kotlin/io/konifer/domain/context/RequestContextValidator.kt
+++ b/service/src/main/kotlin/io/konifer/domain/context/RequestContextValidator.kt
@@ -5,11 +5,14 @@ import io.konifer.common.image.ManipulationParameters.ALL_TRANSFORMATION_PARAMET
 import io.konifer.common.selector.ReturnFormat
 import io.konifer.domain.context.selector.QuerySelectors
 import io.konifer.domain.path.PathConfiguration
+import io.konifer.domain.ports.VariantProfileRepository
 import io.konifer.domain.variant.OnDemandVariantMode
 import io.ktor.http.Parameters
 
-object RequestContextValidator {
-    fun validateGetRequest(
+class RequestContextValidator(
+    private val variantProfileRepository: VariantProfileRepository,
+) {
+    fun validateFetchRequest(
         pathConfiguration: PathConfiguration,
         querySelectors: QuerySelectors,
         requestedTransformation: RequestedTransformation?,
@@ -25,13 +28,38 @@ object RequestContextValidator {
                 }
             }
             ReturnFormat.LINK, ReturnFormat.CONTENT, ReturnFormat.REDIRECT, ReturnFormat.DOWNLOAD -> {
-                if (
-                    pathConfiguration.transform.onDemandVariant.mode == OnDemandVariantMode.PROFILE_ONLY &&
-                    ALL_TRANSFORMATION_PARAMETERS.any { it.lowercase() in queryParameters }
-                ) {
+                if (requestedTransformation == null || requestedTransformation == RequestedTransformation.ORIGINAL_VARIANT) return
+                validateOnDemandVariantMode(
+                    pathConfiguration = pathConfiguration,
+                    requestedTransformation = requestedTransformation,
+                    queryParameters = queryParameters,
+                )
+            }
+        }
+    }
+
+    private fun validateOnDemandVariantMode(
+        pathConfiguration: PathConfiguration,
+        requestedTransformation: RequestedTransformation,
+        queryParameters: Parameters,
+    ) {
+        when (pathConfiguration.transform.onDemandVariant.mode) {
+            OnDemandVariantMode.PROFILE_ONLY -> {
+                if (ALL_TRANSFORMATION_PARAMETERS.any { it.lowercase() in queryParameters }) {
                     throw IllegalRequestedTransformationException("Only '${ManipulationParameters.VARIANT_PROFILE}' can be specified")
                 }
             }
+            OnDemandVariantMode.DISABLED -> {
+                val allowedTransformations =
+                    pathConfiguration.transform.eagerVariants.map { profileName ->
+                        variantProfileRepository.fetch(profileName)
+                    }
+                // Only eager variants allowed since on-demand variants are disabled
+                if (requestedTransformation !in allowedTransformations) {
+                    throw IllegalRequestedTransformationException("Transformation not allowed")
+                }
+            }
+            OnDemandVariantMode.ENABLED -> {}
         }
     }
 }

--- a/service/src/main/kotlin/io/konifer/domain/variant/OnDemandVariantProperties.kt
+++ b/service/src/main/kotlin/io/konifer/domain/variant/OnDemandVariantProperties.kt
@@ -20,6 +20,7 @@ data class OnDemandVariantProperties(
 enum class OnDemandVariantMode {
     ENABLED,
     PROFILE_ONLY,
+    DISABLED,
     ;
 
     companion object Factory {

--- a/service/src/main/kotlin/io/konifer/infrastructure/KtorKoin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/KtorKoin.kt
@@ -9,6 +9,7 @@ import io.konifer.application.usecase.store.StoreNewAssetUseCase
 import io.konifer.application.usecase.update.UpdateAssetUseCase
 import io.konifer.domain.asset.FormatValidator
 import io.konifer.domain.context.RequestContextFactory
+import io.konifer.domain.context.RequestContextValidator
 import io.konifer.domain.ports.EventBus
 import io.konifer.domain.ports.EventPublisher
 import io.konifer.domain.transformation.TransformationNormalizer
@@ -74,6 +75,7 @@ fun Application.configModule(): Module =
 fun domainModule(): Module =
     module {
         single<RequestContextFactory>()
+        single<RequestContextValidator>()
         single<TransformationNormalizer>()
         single<VariantService>()
         singleOf(::InMemoryEventBus) {

--- a/service/src/main/kotlin/io/konifer/infrastructure/http/RequestContextPlugin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/http/RequestContextPlugin.kt
@@ -23,7 +23,7 @@ val RequestContextPlugin =
             when (call.request.httpMethod) {
                 HttpMethod.Get -> {
                     call.attributes[queryRequestContextKey] =
-                        requestContextFactory.fromGetRequest(
+                        requestContextFactory.fromFetchRequest(
                             path = call.request.path(),
                             headers = call.request.headers,
                             queryParameters = call.parameters,

--- a/service/src/test/kotlin/io/konifer/domain/context/RequestContextFactoryTest.kt
+++ b/service/src/test/kotlin/io/konifer/domain/context/RequestContextFactoryTest.kt
@@ -47,6 +47,7 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
+import org.junitpioneer.jupiter.cartesian.CartesianTest
 
 class RequestContextFactoryTest : BaseUnitTest() {
     companion object {
@@ -596,8 +597,9 @@ class RequestContextFactoryTest : BaseUnitTest() {
     private val pathConfigurationRepository = mockk<TriePathConfigurationRepository>()
     private val variantProfileRepository = mockk<ConfigurationVariantProfileRepository>()
     private val transformationNormalizer = TransformationNormalizer(assetRepository)
+    private val requestContextValidator = RequestContextValidator(variantProfileRepository)
     private val requestContextFactory =
-        RequestContextFactory(pathConfigurationRepository, variantProfileRepository, transformationNormalizer)
+        RequestContextFactory(pathConfigurationRepository, variantProfileRepository, transformationNormalizer, requestContextValidator)
 
     @BeforeEach
     fun beforeEach() {
@@ -607,7 +609,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
     }
 
     @Nested
-    inner class GetRequestContextTests {
+    inner class FetchRequestContextTests {
         @ParameterizedTest
         @MethodSource("io.konifer.domain.context.RequestContextFactoryTest#queryModifierSource")
         fun `can fetch GET request context with query modifiers`(
@@ -616,7 +618,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
             expectedQuerySelectors: QuerySelectors,
         ) = runTest {
             val context =
-                requestContextFactory.fromGetRequest(
+                requestContextFactory.fromFetchRequest(
                     path = path,
                     headers = HeadersBuilder().build(),
                     queryParameters = queryParameters,
@@ -634,7 +636,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
             expectedQuerySelectors: QuerySelectors,
         ) = runTest {
             val context =
-                requestContextFactory.fromGetRequest(
+                requestContextFactory.fromFetchRequest(
                     path = path,
                     headers = HeadersBuilder().build(),
                     queryParameters = Parameters.Empty,
@@ -661,7 +663,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                 } returns variantConfig
 
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/user/",
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -702,7 +704,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                         format = ImageFormat.PNG,
                     )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/user/",
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -741,7 +743,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
         fun `throws when GET query modifiers are invalid`(path: String) =
             runTest {
                 shouldThrow<InvalidQuerySelectorsException> {
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = path,
                         headers = HeadersBuilder().build(),
                         queryParameters = Parameters.Empty,
@@ -761,7 +763,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
         fun `entryId must be positive when fetching GET request context`(path: String) =
             runTest {
                 shouldThrow<InvalidQuerySelectorsException> {
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = path,
                         headers = HeadersBuilder().build(),
                         queryParameters = Parameters.Empty,
@@ -775,7 +777,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
             runTest {
                 val exception =
                     shouldThrow<InvalidQuerySelectorsException> {
-                        requestContextFactory.fromGetRequest(
+                        requestContextFactory.fromFetchRequest(
                             path = "/assets/profile/user/123/-/$returnFormat",
                             headers = HeadersBuilder().build(),
                             queryParameters =
@@ -795,7 +797,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                 val path = "/assets/profile/-/-/metadata/new/10/"
                 val exception =
                     shouldThrow<InvalidPathException> {
-                        requestContextFactory.fromGetRequest(
+                        requestContextFactory.fromFetchRequest(
                             path = path,
                             headers = HeadersBuilder().build(),
                             queryParameters = Parameters.Empty,
@@ -818,7 +820,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                 path = "/profile/",
             )
             val context =
-                requestContextFactory.fromGetRequest(
+                requestContextFactory.fromFetchRequest(
                     path = path,
                     headers = HeadersBuilder().build(),
                     queryParameters = parameters,
@@ -840,7 +842,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
 
                 val exception =
                     shouldThrow<InvalidPathException> {
-                        requestContextFactory.fromGetRequest(
+                        requestContextFactory.fromFetchRequest(
                             path = "/assets/profile/-/new/metadata/",
                             headers = HeadersBuilder().build(),
                             queryParameters = parameters,
@@ -853,7 +855,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
         fun `can parse GET asset path from the uri request path`() =
             runTest {
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/123/-/metadata/",
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -879,7 +881,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
             runTest {
                 val exception =
                     shouldThrow<InvalidPathException> {
-                        requestContextFactory.fromGetRequest(
+                        requestContextFactory.fromFetchRequest(
                             path = path,
                             headers = HeadersBuilder().build(),
                             queryParameters = Parameters.Empty,
@@ -900,7 +902,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     path = "/profile/",
                 )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = path,
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -937,7 +939,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     path = "/profile/",
                 )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = path,
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -971,7 +973,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     path = "/profile/",
                 )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = path,
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -1004,7 +1006,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     path = "/profile/",
                 )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/content/",
                         headers =
                             HeadersBuilder()
@@ -1027,7 +1029,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     path = "/profile/",
                 )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/content/",
                         headers =
                             HeadersBuilder()
@@ -1056,7 +1058,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                         path = "/profile/",
                     )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/content/",
                         headers =
                             HeadersBuilder()
@@ -1092,7 +1094,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     variantProfileRepository.fetch(profileName)
                 } returns variantConfig
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/content/",
                         headers =
                             HeadersBuilder()
@@ -1120,7 +1122,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                     path = "/profile/",
                 )
                 val context =
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/content/",
                         headers =
                             HeadersBuilder()
@@ -1155,7 +1157,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                             ),
                     )
                 shouldThrow<IllegalRequestedTransformationException> {
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/content/",
                         headers = HeadersBuilder().build(),
                         queryParameters = parameters,
@@ -1180,7 +1182,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                             ),
                     )
                 shouldThrow<IllegalRequestedTransformationException> {
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/${returnFormat.name.lowercase()}/",
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -1223,7 +1225,7 @@ class RequestContextFactoryTest : BaseUnitTest() {
                         format = ImageFormat.JPEG,
                     )
                 shouldNotThrowAny {
-                    requestContextFactory.fromGetRequest(
+                    requestContextFactory.fromFetchRequest(
                         path = "/assets/profile/-/${returnFormat.name.lowercase()}/",
                         headers = HeadersBuilder().build(),
                         queryParameters =
@@ -1235,36 +1237,37 @@ class RequestContextFactoryTest : BaseUnitTest() {
                 }
             }
 
-        @ParameterizedTest
-        @EnumSource(ReturnFormat::class, mode = EnumSource.Mode.EXCLUDE, names = ["METADATA"])
-        fun `can specify original variant with profile_only mode`(returnFormat: ReturnFormat) =
-            runTest {
-                storePersistedAsset(
-                    height = 100,
-                    width = 100,
-                    format = ImageFormat.PNG,
-                    path = "/profile/",
+        @CartesianTest
+        fun `can specify original variant with on-demand variant profile modes`(
+            @CartesianTest.Enum(ReturnFormat::class) returnFormat: ReturnFormat,
+            @CartesianTest.Enum(OnDemandVariantMode::class) mode: OnDemandVariantMode,
+        ) = runTest {
+            storePersistedAsset(
+                height = 100,
+                width = 100,
+                format = ImageFormat.PNG,
+                path = "/profile/",
+            )
+            every {
+                pathConfigurationRepository.fetch(path = any())
+            } returns
+                PathConfiguration(
+                    transform =
+                        TransformProperties(
+                            onDemandVariant =
+                                OnDemandVariantProperties(
+                                    mode = mode,
+                                ),
+                        ),
                 )
-                every {
-                    pathConfigurationRepository.fetch(path = any())
-                } returns
-                    PathConfiguration(
-                        transform =
-                            TransformProperties(
-                                onDemandVariant =
-                                    OnDemandVariantProperties(
-                                        mode = OnDemandVariantMode.PROFILE_ONLY,
-                                    ),
-                            ),
-                    )
-                shouldNotThrowAny {
-                    requestContextFactory.fromGetRequest(
-                        path = "/assets/profile/-/${returnFormat.name.lowercase()}/",
-                        headers = HeadersBuilder().build(),
-                        queryParameters = ParametersBuilder().build(),
-                    )
-                }
+            shouldNotThrowAny {
+                requestContextFactory.fromFetchRequest(
+                    path = "/assets/profile/-/${returnFormat.name.lowercase()}/",
+                    headers = HeadersBuilder().build(),
+                    queryParameters = ParametersBuilder().build(),
+                )
             }
+        }
     }
 
     @Nested

--- a/service/src/test/kotlin/io/konifer/domain/context/RequestContextValidatorTest.kt
+++ b/service/src/test/kotlin/io/konifer/domain/context/RequestContextValidatorTest.kt
@@ -1,0 +1,209 @@
+package io.konifer.domain.context
+
+import io.konifer.common.image.ManipulationParameters
+import io.konifer.common.selector.ReturnFormat
+import io.konifer.createRequestedImageTransformation
+import io.konifer.domain.context.selector.QuerySelectors
+import io.konifer.domain.path.PathConfiguration
+import io.konifer.domain.ports.VariantProfileRepository
+import io.konifer.domain.variant.OnDemandVariantMode
+import io.konifer.domain.variant.OnDemandVariantProperties
+import io.konifer.domain.variant.TransformProperties
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.ktor.http.Parameters
+import io.ktor.http.ParametersBuilder
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
+
+class RequestContextValidatorTest {
+    private val variantProfileRepository = mockk<VariantProfileRepository>()
+    private val validator = RequestContextValidator(variantProfileRepository)
+
+    @Test
+    fun `metadata requests cannot specify image attributes`() {
+        val exception =
+            shouldThrow<InvalidPathException> {
+                validator.validateFetchRequest(
+                    pathConfiguration = pathConfiguration(),
+                    querySelectors = QuerySelectors(returnFormat = ReturnFormat.METADATA),
+                    requestedTransformation = createRequestedImageTransformation(width = 100),
+                    queryParameters = Parameters.Empty,
+                )
+            }
+
+        exception.message shouldBe "Cannot specify image attributes when requesting asset metadata"
+    }
+
+    @Test
+    fun `metadata requests allow the original variant`() {
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.DISABLED),
+                querySelectors = QuerySelectors(returnFormat = ReturnFormat.METADATA),
+                requestedTransformation = RequestedTransformation.ORIGINAL_VARIANT,
+                queryParameters = Parameters.Empty,
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ReturnFormat::class, mode = EnumSource.Mode.EXCLUDE, names = ["METADATA"])
+    fun `non-metadata requests allow omitted transformations`(returnFormat: ReturnFormat) {
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.DISABLED),
+                querySelectors = QuerySelectors(returnFormat = returnFormat),
+                requestedTransformation = null,
+                queryParameters = Parameters.Empty,
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(ReturnFormat::class, mode = EnumSource.Mode.EXCLUDE, names = ["METADATA"])
+    fun `non-metadata requests allow the original variant`(returnFormat: ReturnFormat) {
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.DISABLED),
+                querySelectors = QuerySelectors(returnFormat = returnFormat),
+                requestedTransformation = RequestedTransformation.ORIGINAL_VARIANT,
+                queryParameters = Parameters.Empty,
+            )
+        }
+    }
+
+    @Test
+    fun `enabled on-demand mode allows arbitrary transformations`() {
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.ENABLED),
+                querySelectors = QuerySelectors(returnFormat = ReturnFormat.CONTENT),
+                requestedTransformation = createRequestedImageTransformation(width = 100),
+                queryParameters =
+                    parameters {
+                        append(ManipulationParameters.WIDTH, "100")
+                    },
+            )
+        }
+    }
+
+    @Test
+    fun `profile-only on-demand mode allows profile requests`() {
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.PROFILE_ONLY),
+                querySelectors = QuerySelectors(returnFormat = ReturnFormat.CONTENT),
+                requestedTransformation = createRequestedImageTransformation(width = 100),
+                queryParameters =
+                    parameters {
+                        append(ManipulationParameters.VARIANT_PROFILE, "thumbnail")
+                    },
+            )
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["phone-model", "label:w", "s"])
+    fun `profile-only on-demand mode allows label and other query parameters`(labelKey: String) {
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.PROFILE_ONLY),
+                querySelectors = QuerySelectors(returnFormat = ReturnFormat.CONTENT),
+                requestedTransformation = createRequestedImageTransformation(width = 100),
+                queryParameters =
+                    parameters {
+                        append(labelKey, "value")
+                    },
+            )
+        }
+    }
+
+    @Test
+    fun `profile-only on-demand mode rejects explicit transformation parameters`() {
+        val exception =
+            shouldThrow<IllegalRequestedTransformationException> {
+                validator.validateFetchRequest(
+                    pathConfiguration = pathConfiguration(mode = OnDemandVariantMode.PROFILE_ONLY),
+                    querySelectors = QuerySelectors(returnFormat = ReturnFormat.CONTENT),
+                    requestedTransformation = createRequestedImageTransformation(width = 100),
+                    queryParameters =
+                        parameters {
+                            append(ManipulationParameters.WIDTH, "100")
+                        },
+                )
+            }
+
+        exception.message shouldBe "Only '${ManipulationParameters.VARIANT_PROFILE}' can be specified"
+    }
+
+    @Test
+    fun `disabled on-demand mode allows transformations matching eager variants`() {
+        val thumbnail = createRequestedImageTransformation(width = 100)
+        val small = createRequestedImageTransformation(width = 200)
+        every { variantProfileRepository.fetch("thumbnail") } returns thumbnail
+        every { variantProfileRepository.fetch("small") } returns small
+
+        shouldNotThrowAny {
+            validator.validateFetchRequest(
+                pathConfiguration =
+                    pathConfiguration(
+                        mode = OnDemandVariantMode.DISABLED,
+                        eagerVariants = listOf("thumbnail", "small"),
+                    ),
+                querySelectors = QuerySelectors(returnFormat = ReturnFormat.CONTENT),
+                requestedTransformation = small,
+                queryParameters =
+                    parameters {
+                        append(ManipulationParameters.VARIANT_PROFILE, "small")
+                    },
+            )
+        }
+    }
+
+    @Test
+    fun `disabled on-demand mode rejects transformations that are not eager variants`() {
+        every { variantProfileRepository.fetch("thumbnail") } returns createRequestedImageTransformation(width = 100)
+
+        val exception =
+            shouldThrow<IllegalRequestedTransformationException> {
+                validator.validateFetchRequest(
+                    pathConfiguration =
+                        pathConfiguration(
+                            mode = OnDemandVariantMode.DISABLED,
+                            eagerVariants = listOf("thumbnail"),
+                        ),
+                    querySelectors = QuerySelectors(returnFormat = ReturnFormat.CONTENT),
+                    requestedTransformation = createRequestedImageTransformation(width = 200),
+                    queryParameters =
+                        parameters {
+                            append(ManipulationParameters.WIDTH, "200")
+                        },
+                )
+            }
+
+        exception.message shouldBe "Transformation not allowed"
+    }
+
+    private fun pathConfiguration(
+        mode: OnDemandVariantMode = OnDemandVariantMode.ENABLED,
+        eagerVariants: List<String> = emptyList(),
+    ): PathConfiguration =
+        PathConfiguration(
+            transform =
+                TransformProperties(
+                    eagerVariants = eagerVariants,
+                    onDemandVariant = OnDemandVariantProperties(mode = mode),
+                ),
+        )
+
+    private fun parameters(block: ParametersBuilder.() -> Unit): Parameters =
+        ParametersBuilder()
+            .apply(block)
+            .build()
+}


### PR DESCRIPTION
This will help customers restrict variant generation to be eagerly-defined transformations only.