### PR TITLE
Synchronously delete variants from object store when using in-memory data store

### DIFF
--- a/service/src/main/kotlin/io/konifer/application/usecase/delete/DeleteAssetUseCase.kt
+++ b/service/src/main/kotlin/io/konifer/application/usecase/delete/DeleteAssetUseCase.kt
@@ -1,38 +1,42 @@
 package io.konifer.application.usecase.delete
 
 import io.konifer.domain.context.DeleteRequestContext
-import io.konifer.domain.ports.AssetRepository
+import io.konifer.domain.ports.AssetDeleter
+import io.konifer.domain.ports.DeleteAssetsCommand
 import io.ktor.util.logging.KtorSimpleLogger
 
 class DeleteAssetUseCase(
-    private val assetRepository: AssetRepository,
+    private val assetDeleter: AssetDeleter,
 ) {
     private val logger = KtorSimpleLogger(this::class.qualifiedName!!)
 
     suspend fun deleteAssets(context: DeleteRequestContext) {
-        if (context.modifiers.entryId != null) {
-            logger.info("Deleting asset with path: ${context.path} and entryId: ${context.modifiers.entryId}")
-            assetRepository.deleteByPath(
-                path = context.path,
-                entryId = context.modifiers.entryId,
-            )
-        } else if (context.modifiers.recursive) {
-            logger.info("Deleting assets recursively at path: ${context.path} with labels: ${context.labels}")
-            assetRepository.deleteRecursivelyByPath(
-                path = context.path,
-                labels = context.labels,
-            )
-        } else {
-            logger.info(
-                "Deleting assets at path: ${context.path} with labels: ${context.labels} ordering by: ${context.modifiers.order}" +
-                    " and limit: ${context.modifiers.limit}",
-            )
-            assetRepository.deleteAllByPath(
-                path = context.path,
-                labels = context.labels,
-                order = context.modifiers.order,
-                limit = context.modifiers.limit,
-            )
-        }
+        val command =
+            if (context.modifiers.entryId != null) {
+                logger.info("Deleting asset with path: ${context.path} and entryId: ${context.modifiers.entryId}")
+                DeleteAssetsCommand.Entry(
+                    path = context.path,
+                    entryId = context.modifiers.entryId,
+                )
+            } else if (context.modifiers.recursive) {
+                logger.info("Deleting assets recursively at path: ${context.path} with labels: ${context.labels}")
+                DeleteAssetsCommand.Recursively(
+                    path = context.path,
+                    labels = context.labels,
+                )
+            } else {
+                logger.info(
+                    "Deleting assets at path: ${context.path} with labels: ${context.labels} ordering by: ${context.modifiers.order}" +
+                        " and limit: ${context.modifiers.limit}",
+                )
+                DeleteAssetsCommand.AtPath(
+                    path = context.path,
+                    labels = context.labels,
+                    order = context.modifiers.order,
+                    limit = context.modifiers.limit,
+                )
+            }
+
+        assetDeleter.delete(command)
     }
 }

--- a/service/src/main/kotlin/io/konifer/domain/ports/AssetDeleter.kt
+++ b/service/src/main/kotlin/io/konifer/domain/ports/AssetDeleter.kt
@@ -1,0 +1,26 @@
+package io.konifer.domain.ports
+
+import io.konifer.common.selector.Order
+
+interface AssetDeleter {
+    suspend fun delete(command: DeleteAssetsCommand)
+}
+
+sealed interface DeleteAssetsCommand {
+    data class Entry(
+        val path: String,
+        val entryId: Long,
+    ) : DeleteAssetsCommand
+
+    data class AtPath(
+        val path: String,
+        val labels: Map<String, String>,
+        val order: Order,
+        val limit: Int,
+    ) : DeleteAssetsCommand
+
+    data class Recursively(
+        val path: String,
+        val labels: Map<String, String>,
+    ) : DeleteAssetsCommand
+}

--- a/service/src/main/kotlin/io/konifer/infrastructure/datastore/Koin.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/datastore/Koin.kt
@@ -1,7 +1,10 @@
 package io.konifer.infrastructure.datastore
 
+import io.konifer.domain.ports.AssetDeleter
 import io.konifer.domain.ports.AssetRepository
+import io.konifer.infrastructure.datastore.inmemory.InMemoryAssetDeleter
 import io.konifer.infrastructure.datastore.inmemory.InMemoryAssetRepository
+import io.konifer.infrastructure.datastore.postgres.PostgresAssetDeleter
 import io.konifer.infrastructure.datastore.postgres.PostgresAssetRepository
 import io.konifer.infrastructure.datastore.postgres.PostgresVariantRepository
 import io.konifer.infrastructure.datastore.postgres.createPostgresProperties
@@ -37,6 +40,7 @@ fun Application.assetRepositoryModule(datastoreProvider: DataStoreProvider): Mod
         when (datastoreProvider) {
             DataStoreProvider.IN_MEMORY -> {
                 single<InMemoryAssetRepository>() bind AssetRepository::class
+                single<InMemoryAssetDeleter>() bind AssetDeleter::class
             }
             DataStoreProvider.POSTGRES -> {
                 val properties = createPostgresProperties()
@@ -72,6 +76,7 @@ fun Application.assetRepositoryModule(datastoreProvider: DataStoreProvider): Mod
                 } withOptions {
                     createdAtStart()
                 }
+                single<PostgresAssetDeleter>() bind AssetDeleter::class
             }
         }
     }

--- a/service/src/main/kotlin/io/konifer/infrastructure/datastore/inmemory/InMemoryAssetDeleter.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/datastore/inmemory/InMemoryAssetDeleter.kt
@@ -1,0 +1,24 @@
+package io.konifer.infrastructure.datastore.inmemory
+
+import io.konifer.domain.ports.AssetDeleter
+import io.konifer.domain.ports.DeleteAssetsCommand
+import io.konifer.domain.ports.ObjectStore
+
+class InMemoryAssetDeleter(
+    private val objectStore: ObjectStore,
+    private val assetRepository: InMemoryAssetRepository,
+) : AssetDeleter {
+    override suspend fun delete(command: DeleteAssetsCommand) {
+        val grouped =
+            assetRepository
+                .deleteAndReturnObjectReferences(command)
+                .groupByTo(mutableMapOf(), { it.bucket }) { it.key }
+
+        for ((bucket, keys) in grouped) {
+            objectStore.deleteAll(
+                bucket = bucket,
+                keys = keys,
+            )
+        }
+    }
+}

--- a/service/src/main/kotlin/io/konifer/infrastructure/datastore/inmemory/InMemoryAssetRepository.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/datastore/inmemory/InMemoryAssetRepository.kt
@@ -5,6 +5,7 @@ import io.konifer.domain.asset.Asset
 import io.konifer.domain.asset.AssetData
 import io.konifer.domain.asset.AssetId
 import io.konifer.domain.ports.AssetRepository
+import io.konifer.domain.ports.DeleteAssetsCommand
 import io.konifer.domain.variant.Transformation
 import io.konifer.domain.variant.Variant
 import io.konifer.domain.variant.VariantAlreadyExistsException
@@ -16,6 +17,11 @@ import java.time.ZoneOffset.UTC
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
+
+internal data class ObjectStoreReference(
+    val bucket: String,
+    val key: String,
+)
 
 class InMemoryAssetRepository : AssetRepository {
     private val logger = KtorSimpleLogger(this::class.qualifiedName!!)
@@ -62,13 +68,16 @@ class InMemoryAssetRepository : AssetRepository {
     }
 
     override suspend fun markUploaded(variant: Variant.Ready) {
-        val asset = idReference[variant.assetId] ?: return
-        store[asset.path]
-            ?.firstOrNull { it.entryId == asset.entryId }
-            ?.let { asset ->
-                asset.variants.removeIf { it.id == variant.id }
-                asset.variants.add(variant)
-            }
+        storeMutex.withLock {
+            val asset = idReference[variant.assetId] ?: return
+            val path = InMemoryPathAdapter.toInMemoryPathFromUriPath(asset.path)
+            store[path]
+                ?.firstOrNull { it.entryId == asset.entryId }
+                ?.let { asset ->
+                    asset.variants.removeIf { it.id == variant.id }
+                    asset.variants.add(variant)
+                }
+        }
     }
 
     override suspend fun storeNewVariant(variant: Variant.Pending): Variant.Pending {
@@ -143,20 +152,12 @@ class InMemoryAssetRepository : AssetRepository {
         path: String,
         entryId: Long,
     ) {
-        val inMemoryPath = InMemoryPathAdapter.toInMemoryPathFromUriPath(path)
-        logger.info("Deleting asset at path: $inMemoryPath, entryId: $entryId")
-
-        val asset =
-            store[inMemoryPath]?.let { assets ->
-                assets.firstOrNull { it.entryId == entryId }
-            }
-
-        asset?.let {
-            idReference.remove(it.id)
-        }
-        store[inMemoryPath]?.let { assets ->
-            assets.removeIf { it.entryId == entryId }
-        }
+        deleteAndReturnObjectReferences(
+            DeleteAssetsCommand.Entry(
+                path = path,
+                entryId = entryId,
+            ),
+        )
     }
 
     override suspend fun deleteAllByPath(
@@ -165,54 +166,86 @@ class InMemoryAssetRepository : AssetRepository {
         order: Order,
         limit: Int,
     ) {
-        val inMemoryPath = InMemoryPathAdapter.toInMemoryPathFromUriPath(path)
-        logger.info("Deleting assets at path: $inMemoryPath, labels: $labels, orderBy: $order, limit: $limit")
-        val assetsToDelete =
-            fetchAll(
+        deleteAndReturnObjectReferences(
+            DeleteAssetsCommand.AtPath(
                 path = path,
-                order = order,
-                transformation = null,
-                limit = limit,
                 labels = labels,
-                includeOnlyReady = false,
-            )
-        assetsToDelete.map { it.id }.forEach {
-            idReference.remove(it)
-        }
-        store[inMemoryPath]?.let { assets ->
-            assets.removeIf { asset -> asset.id in assetsToDelete.map { it.id } }
-        }
+                order = order,
+                limit = limit,
+            ),
+        )
     }
 
     override suspend fun deleteRecursivelyByPath(
         path: String,
         labels: Map<String, String>,
     ) {
-        val inMemoryPath = InMemoryPathAdapter.toInMemoryPathFromUriPath(path)
-        logger.info("Deleting assets (recursively) at path: $inMemoryPath with labels: $labels")
-        store.keys.filter { it.startsWith(inMemoryPath) }.forEach { path ->
-            val assetAndVariants = store[path] ?: emptyList()
-            val assetsToDelete = assetAndVariants.filter { labels.all { entry -> it.labels.asMap()[entry.key] == entry.value } }
-            assetsToDelete.map { it.id }.forEach {
-                idReference.remove(it)
-            }
-            store[path]?.let { assets ->
-                assets.removeIf { asset -> asset.id in assetsToDelete.map { it.id } }
-            }
-        }
+        deleteAndReturnObjectReferences(
+            DeleteAssetsCommand.Recursively(
+                path = path,
+                labels = labels,
+            ),
+        )
     }
 
     override suspend fun deleteByAssetId(assetId: AssetId) {
         logger.info("Deleting asset with id: : $assetId")
 
-        idReference[assetId]?.let { asset ->
-            idReference.remove(asset.id)
-            val path = InMemoryPathAdapter.toInMemoryPathFromUriPath(asset.path)
-            store[path]?.let { assets ->
-                assets.removeIf { it.id == assetId }
+        storeMutex.withLock {
+            idReference[assetId]?.let { asset ->
+                removeAssets(listOf(asset))
             }
         }
     }
+
+    internal suspend fun deleteAndReturnObjectReferences(command: DeleteAssetsCommand): List<ObjectStoreReference> =
+        storeMutex.withLock {
+            val assets =
+                when (command) {
+                    is DeleteAssetsCommand.Entry -> {
+                        val path = InMemoryPathAdapter.toInMemoryPathFromUriPath(command.path)
+                        logger.info("Deleting asset at path: $path, entryId: ${command.entryId}")
+                        store[path]
+                            ?.firstOrNull { it.entryId == command.entryId }
+                            ?.let(::listOf)
+                            ?: emptyList()
+                    }
+                    is DeleteAssetsCommand.AtPath -> {
+                        val path = InMemoryPathAdapter.toInMemoryPathFromUriPath(command.path)
+                        logger.info(
+                            "Deleting assets at path: $path, labels: ${command.labels}, " +
+                                "orderBy: ${command.order}, limit: ${command.limit}",
+                        )
+                        selectAssetsAtPath(
+                            path = path,
+                            labels = command.labels,
+                            order = command.order,
+                            limit = command.limit,
+                        )
+                    }
+                    is DeleteAssetsCommand.Recursively -> {
+                        val path = InMemoryPathAdapter.toInMemoryPathFromUriPath(command.path)
+                        logger.info("Deleting assets (recursively) at path: $path with labels: ${command.labels}")
+                        store.keys
+                            .filter { it.startsWith(path) }
+                            .flatMap { storedPath ->
+                                store[storedPath]
+                                    ?.filter { asset ->
+                                        command.labels.all { entry -> asset.labels.asMap()[entry.key] == entry.value }
+                                    }.orEmpty()
+                            }
+                    }
+                }
+
+            val objectReferences =
+                assets
+                    .flatMap { it.variants }
+                    .map { ObjectStoreReference(bucket = it.objectStoreBucket, key = it.objectStoreKey) }
+                    .distinct()
+
+            removeAssets(assets)
+            objectReferences
+        }
 
     override suspend fun update(asset: Asset): Asset {
         if (asset !is Asset.Ready) {
@@ -225,6 +258,36 @@ class InMemoryAssetRepository : AssetRepository {
         store[path]?.add(asset)
 
         return asset
+    }
+
+    private fun selectAssetsAtPath(
+        path: String,
+        labels: Map<String, String>,
+        order: Order,
+        limit: Int,
+    ): List<Asset> =
+        store[path]
+            ?.asSequence()
+            ?.filter { asset -> labels.all { entry -> asset.labels.asMap()[entry.key] == entry.value } }
+            ?.sortedWith(
+                when (order) {
+                    Order.NEW -> compareByDescending<Asset> { it.createdAt }
+                    Order.MODIFIED -> compareByDescending { it.modifiedAt }
+                }.thenByDescending { it.entryId },
+            )?.let { assets ->
+                if (limit > 0) assets.take(limit) else assets
+            }?.toList()
+            ?: emptyList()
+
+    private fun removeAssets(assets: List<Asset>) {
+        val ids = assets.mapTo(mutableSetOf()) { it.id }
+        ids.forEach(idReference::remove)
+        assets
+            .map { InMemoryPathAdapter.toInMemoryPathFromUriPath(it.path) }
+            .distinct()
+            .forEach { path ->
+                store[path]?.removeIf { it.id in ids }
+            }
     }
 
     private fun getNextEntryId(path: String): Long =

--- a/service/src/main/kotlin/io/konifer/infrastructure/datastore/postgres/PostgresAssetDeleter.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/datastore/postgres/PostgresAssetDeleter.kt
@@ -1,0 +1,35 @@
+package io.konifer.infrastructure.datastore.postgres
+
+import io.konifer.domain.ports.AssetDeleter
+import io.konifer.domain.ports.AssetRepository
+import io.konifer.domain.ports.DeleteAssetsCommand
+
+class PostgresAssetDeleter(
+    private val assetRepository: AssetRepository,
+) : AssetDeleter {
+    /**
+     * When assets are deleted within Postgres, the variant references to the object store are
+     * saved to an outbox where scheduled variant deletion occurs on a scheduled basis
+     */
+    override suspend fun delete(command: DeleteAssetsCommand) {
+        when (command) {
+            is DeleteAssetsCommand.Entry ->
+                assetRepository.deleteByPath(
+                    path = command.path,
+                    entryId = command.entryId,
+                )
+            is DeleteAssetsCommand.AtPath ->
+                assetRepository.deleteAllByPath(
+                    path = command.path,
+                    labels = command.labels,
+                    order = command.order,
+                    limit = command.limit,
+                )
+            is DeleteAssetsCommand.Recursively ->
+                assetRepository.deleteRecursivelyByPath(
+                    path = command.path,
+                    labels = command.labels,
+                )
+        }
+    }
+}

--- a/service/src/test/kotlin/io/konifer/infrastructure/datastore/inmemory/InMemoryAssetDeleterTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/datastore/inmemory/InMemoryAssetDeleterTest.kt
@@ -1,0 +1,143 @@
+package io.konifer.infrastructure.datastore.inmemory
+
+import io.konifer.common.image.ImageFormat
+import io.konifer.common.selector.Order
+import io.konifer.domain.image.ColorSpace
+import io.konifer.domain.ports.DeleteAssetsCommand
+import io.konifer.domain.ports.ObjectStore
+import io.konifer.domain.variant.Transformation
+import io.konifer.infrastructure.datastore.createPendingAsset
+import io.konifer.infrastructure.datastore.createPendingVariant
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+
+class InMemoryAssetDeleterTest {
+    private val objectStore = mockk<ObjectStore>(relaxed = true)
+    private val assetRepository = InMemoryAssetRepository()
+    private val assetDeleter = InMemoryAssetDeleter(objectStore, assetRepository)
+
+    @Test
+    fun `deletes every object belonging to an entry`() =
+        runTest {
+            val originalKey = "original.png"
+            val variantKey = "expired-variant.webp"
+            val asset =
+                assetRepository
+                    .storeNew(
+                        createPendingAsset(
+                            objectStoreBucket = "originals",
+                            objectStoreKey = originalKey,
+                        ),
+                    ).markReady(LocalDateTime.now(UTC))
+                    .also { assetRepository.markReady(it) }
+            assetRepository.storeNewVariant(
+                createPendingVariant(
+                    assetId = asset.id,
+                    objectStoreBucket = "variants",
+                    objectStoreKey = variantKey,
+                    transformation =
+                        Transformation(
+                            width = 50,
+                            height = 50,
+                            format = ImageFormat.WEBP,
+                            colorSpace = ColorSpace.SRGB,
+                        ),
+                    expiresAt = LocalDateTime.now(UTC).minusDays(1),
+                ),
+            )
+
+            assetDeleter.delete(
+                DeleteAssetsCommand.Entry(
+                    path = asset.path,
+                    entryId = checkNotNull(asset.entryId),
+                ),
+            )
+
+            coVerify(exactly = 1) { objectStore.deleteAll("originals", listOf(originalKey)) }
+            coVerify(exactly = 1) { objectStore.deleteAll("variants", listOf(variantKey)) }
+            assetRepository.fetchByPath(
+                path = asset.path,
+                entryId = asset.entryId,
+                transformation = null,
+                includeOnlyReady = false,
+            ) shouldBe null
+        }
+
+    @Test
+    fun `deletes objects belonging to pending assets at a path`() =
+        runTest {
+            val key = "pending.png"
+            val asset =
+                assetRepository.storeNew(
+                    createPendingAsset(
+                        objectStoreBucket = "bucket",
+                        objectStoreKey = key,
+                    ),
+                )
+
+            assetDeleter.delete(
+                DeleteAssetsCommand.AtPath(
+                    path = asset.path,
+                    labels = emptyMap(),
+                    order = Order.NEW,
+                    limit = -1,
+                ),
+            )
+
+            coVerify(exactly = 1) { objectStore.deleteAll("bucket", listOf(key)) }
+            assetRepository.fetchByPath(
+                path = asset.path,
+                entryId = asset.entryId,
+                transformation = null,
+                includeOnlyReady = false,
+            ) shouldBe null
+        }
+
+    @Test
+    fun `recursive deletion only cleans objects for matching labels`() =
+        runTest {
+            val deleted =
+                assetRepository.storeNew(
+                    createPendingAsset(
+                        path = "/users/123/profile",
+                        labels = mapOf("animal" to "cat"),
+                        objectStoreKey = "cat.png",
+                    ),
+                )
+            val retained =
+                assetRepository.storeNew(
+                    createPendingAsset(
+                        path = "/users/123/avatar",
+                        labels = mapOf("animal" to "dog"),
+                        objectStoreKey = "dog.png",
+                    ),
+                )
+
+            assetDeleter.delete(
+                DeleteAssetsCommand.Recursively(
+                    path = "/users/123",
+                    labels = mapOf("animal" to "cat"),
+                ),
+            )
+
+            coVerify(exactly = 1) { objectStore.deleteAll("bucket", listOf("cat.png")) }
+            assetRepository.fetchByPath(
+                path = deleted.path,
+                entryId = deleted.entryId,
+                transformation = null,
+                includeOnlyReady = false,
+            ) shouldBe null
+            assetRepository
+                .fetchByPath(
+                    path = retained.path,
+                    entryId = retained.entryId,
+                    transformation = null,
+                    includeOnlyReady = false,
+                )?.id shouldBe retained.id
+        }
+}

--- a/service/src/test/kotlin/io/konifer/infrastructure/datastore/postgres/PostgresAssetDeleterTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/datastore/postgres/PostgresAssetDeleterTest.kt
@@ -1,0 +1,62 @@
+package io.konifer.infrastructure.datastore.postgres
+
+import io.konifer.common.selector.Order
+import io.konifer.domain.ports.AssetRepository
+import io.konifer.domain.ports.DeleteAssetsCommand
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class PostgresAssetDeleterTest {
+    private val assetRepository = mockk<AssetRepository>(relaxed = true)
+    private val assetDeleter = PostgresAssetDeleter(assetRepository)
+
+    @Test
+    fun `delegates entry deletion to repository`() =
+        runTest {
+            assetDeleter.delete(DeleteAssetsCommand.Entry(path = "/users/123", entryId = 4))
+
+            coVerify(exactly = 1) { assetRepository.deleteByPath(path = "/users/123", entryId = 4) }
+        }
+
+    @Test
+    fun `delegates path deletion to repository`() =
+        runTest {
+            assetDeleter.delete(
+                DeleteAssetsCommand.AtPath(
+                    path = "/users/123",
+                    labels = mapOf("animal" to "cat"),
+                    order = Order.MODIFIED,
+                    limit = 5,
+                ),
+            )
+
+            coVerify(exactly = 1) {
+                assetRepository.deleteAllByPath(
+                    path = "/users/123",
+                    labels = mapOf("animal" to "cat"),
+                    order = Order.MODIFIED,
+                    limit = 5,
+                )
+            }
+        }
+
+    @Test
+    fun `delegates recursive deletion to repository`() =
+        runTest {
+            assetDeleter.delete(
+                DeleteAssetsCommand.Recursively(
+                    path = "/users/123",
+                    labels = mapOf("animal" to "cat"),
+                ),
+            )
+
+            coVerify(exactly = 1) {
+                assetRepository.deleteRecursivelyByPath(
+                    path = "/users/123",
+                    labels = mapOf("animal" to "cat"),
+                )
+            }
+        }
+}


### PR DESCRIPTION
This will help with the Cloudflare R2 integration guide that rely on an in-memory data store. Previously, objects were never deleted from the object store which is not a good demonstration of Konifer despite not being a production use case.